### PR TITLE
Give a name to I18NFacetTitlesVocabularyFactory

### DIFF
--- a/src/collective/solr/configure.zcml
+++ b/src/collective/solr/configure.zcml
@@ -59,7 +59,9 @@
       factory=".vocabularies.SolrIndexes"
       name="collective.solr.indexes" />
 
-  <utility factory=".vocabularies.I18NFacetTitlesVocabularyFactory" />
+  <utility 
+      factory=".vocabularies.I18NFacetTitlesVocabularyFactory"
+      name="I18NFacetTitlesVocabularyFactory" />
 
   <!-- Use the proper portal_types tool for type titles -->
   <utility


### PR DESCRIPTION
The vocabulary "I18NFacetTitlesVocabularyFactory" had no name in collective/solr/configure.zcml.
(Without this name, it conflicts with eea.facetednavigation)
