### PR TITLE
Add configuration of solr port, host and base with zcml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changelog
 4.0 - unreleased
 ----------------
 
+- Add configuration for solr host, port and base throught zcml. This is
+  ported from ftw.solr. [csenger, buchi]
+
 - Set max_results param to '10000000' as default value as described in
   http://wiki.apache.org/solr/CommonQueryParameters#rows. It seems this has
   changed in Solr 4.

--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,18 @@ Note that the example solr.cfg is bound to change. Always copy the file to your
 local buildout. In general you should never rely on extending buildout config
 files from servers that aren't under your control.
 
+Solr connection configuration in ZCML
+-------------------------------------
+
+The connections settings for Solr can be configured in ZCML and thus in
+buildout. This makes it easier when copying databases between multiple Zope
+instances with different Solr servers. Example::
+
+    zcml-additional =
+        <configure xmlns:solr="http://namespaces.plone.org/solr">
+            <solr:connection host="localhost" port="8983" base="/solr"/>
+       </configure>
+
 
 Features
 ========

--- a/src/collective/solr/interfaces.py
+++ b/src/collective/solr/interfaces.py
@@ -261,6 +261,11 @@ class ISolrConnectionConfig(ISolrSchema):
     """ utility to hold the connection configuration for the solr server """
 
 
+class IZCMLSolrConnectionConfig(Interface):
+    """Solr connection settings configured through ZCML.
+    """
+
+
 class ISolrConnectionManager(Interface):
     """ a thread-local connection manager for solr """
 

--- a/src/collective/solr/manager.py
+++ b/src/collective/solr/manager.py
@@ -1,9 +1,10 @@
 from logging import getLogger
 from persistent import Persistent
 from zope.interface import implements
-from zope.component import getUtility
+from zope.component import getUtility, queryUtility
 from collective.solr.interfaces import ISolrConnectionConfig
 from collective.solr.interfaces import ISolrConnectionManager
+from collective.solr.interfaces import IZCMLSolrConnectionConfig
 from collective.solr.solr import SolrConnection
 from collective.solr.local import getLocal, setLocal
 from httplib import CannotSendRequest, ResponseNotReady
@@ -57,6 +58,15 @@ class SolrConnectionConfig(BaseSolrConnectionConfig, Persistent):
         return 'solr'
 
 
+class ZCMLSolrConnectionConfig(object):
+    '''Connection values that can be configured through zcml'''
+    implements(IZCMLSolrConnectionConfig)
+
+    def __init__(self, host, port, base):
+        self.host = '%s:%d' % (host, port)
+        self.base = base
+
+
 class SolrConnectionManager(object):
     """ a thread-local connection manager for solr """
     implements(ISolrConnectionManager)
@@ -92,6 +102,18 @@ class SolrConnectionManager(object):
         if not config.active:
             return None
         conn = getLocal('connection')
+
+        # Try to open connection defined in zcml.
+        if conn is None:
+            zcmlconfig = queryUtility(IZCMLSolrConnectionConfig)
+            if zcmlconfig is not None:
+                logger.debug('opening connection to %s', zcmlconfig.host)
+                conn = SolrConnection(host=zcmlconfig.host,
+                                      solrBase=zcmlconfig.base,
+                                      persistent=True)
+                setLocal('connection', conn)
+
+        # Open the connection defined in control panel if we don't have one yet.
         if conn is None and config.host is not None:
             host = '%s:%d' % (config.host, config.port)
             logger.debug('opening connection to %s', host)

--- a/src/collective/solr/meta.zcml
+++ b/src/collective/solr/meta.zcml
@@ -1,0 +1,16 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:meta="http://namespaces.zope.org/meta">
+
+  <include package="zope.component" file="meta.zcml" />
+  
+  <meta:directives namespace="http://namespaces.plone.org/solr">
+
+    <meta:directive
+       name="connection"
+       schema=".zcml.ISolrConnectionConfigDirective"
+       handler=".zcml.solrConnectionConfigDirective"
+       />
+
+  </meta:directives>
+
+</configure>

--- a/src/collective/solr/zcml.py
+++ b/src/collective/solr/zcml.py
@@ -1,0 +1,35 @@
+from zope.interface import Interface
+from zope import schema
+from zope.component.zcml import utility
+
+from collective.solr.interfaces import IZCMLSolrConnectionConfig
+from collective.solr.manager import ZCMLSolrConnectionConfig
+
+
+class ISolrConnectionConfigDirective(Interface):
+    """Directive which registers a Solr connection config"""
+
+    host = schema.ASCIILine(
+        title=u"Host",
+        description=u"The host name of the Solr instance to be used.",
+        required=True,
+    )
+
+    port = schema.Int(
+        title=u"Port",
+        description=u"The port of the Solr instance to be used.",
+        required=True,
+    )
+
+    base = schema.ASCIILine(
+        title=u"Base",
+        description=u"The base prefix of the Solr instance to be used.",
+        required=True,
+    )
+
+
+def solrConnectionConfigDirective(_context, host, port, base):
+
+    utility(_context,
+            provides=IZCMLSolrConnectionConfig,
+            component=ZCMLSolrConnectionConfig(host, port, base))


### PR DESCRIPTION
This is a port from [ftw.solr](https://pypi.python.org/pypi/ftw.solr/) to configure solr connection settings through zcml.

The zcml configuration takes precedence over the configuration in the configlet. If there is no zcml configuration, or the values configured in zcml don't create a connection, the connection is created from the configlet values.
