### PR TITLE
fix typo in facet search; add facet title vocabulary factory for review_state

### DIFF
--- a/src/collective/solr/configure.zcml
+++ b/src/collective/solr/configure.zcml
@@ -86,7 +86,12 @@
   <utility
       component="plone.app.vocabularies.types.PortalTypesVocabularyFactory"
       provides=".interfaces.IFacetTitleVocabularyFactory"
-      name="portal_types" />
+      name="portal_type" />
+
+  <utility
+      component="plone.app.vocabularies.workflow.WorkflowStatesVocabularyFactory"
+      provides=".interfaces.IFacetTitleVocabularyFactory"
+      name="review_state" />
 
   <adapter name="path_string" factory=".attributes.path_string" />
   <adapter name="path_depth" factory=".attributes.path_depth" />


### PR DESCRIPTION
facets.py uses names extracted from the query (for the facet.field parameter) to determine a named utility for looking up the term to use for an items portal_type. However there's a typo in configure.zcml which leads to the default IFacetTitleVocabularyFactory being looked up instead of the correct factory for the portal_type. As a result, you will see the type name instead of the title.

I have also added a named utility for looking up review_state translations.
[replacement for issue #24]
