### PR TITLE
Added ignore_portal_types and only_portal_types parameter to reindex for maintenance_view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog
   catalog attribute.
   [cekk]
 
+- Added ignore_portal_types and only_portal_types parameter to reindex for maintenance_view [jkubaile]
+
 
 4.0.3 (2014-06-18)
 ------------------

--- a/src/collective/solr/browser/maintenance.py
+++ b/src/collective/solr/browser/maintenance.py
@@ -93,9 +93,15 @@ class SolrMaintenanceView(BrowserView):
         conn.commit()
         return 'solr index cleared.'
 
-    def reindex(self, batch=1000, skip=0, limit=0):
+    def reindex(self, batch=1000, skip=0, limit=0, ignore_portal_types=[],
+                only_portal_types=[]):
         """ find all contentish objects (meaning all objects derived from one
             of the catalog mixin classes) and (re)indexes them """
+
+        if ignore_portal_types and only_portal_types:
+            return "It is not possible to combine ignore_portal_types" \
+                " with only_portal_types"
+
         manager = queryUtility(ISolrConnectionManager)
         proc = SolrIndexProcessor(manager)
         conn = manager.getConnection()
@@ -134,24 +140,33 @@ class SolrMaintenanceView(BrowserView):
                 count += 1
                 if count <= skip:
                     continue
-                data, missing = proc.getData(obj)
-                prepareData(data)
-                if not missing:
-                    value = data.get(key, None)
-                    if value is not None:
-                        log('indexing %r\n' % obj)
-                        pt = data.get('portal_type', 'default')
-                        adder = queryAdapter(obj, ISolrAddHandler, name=pt)
-                        if adder is None:
-                            adder = DefaultAdder(obj)
-                        data['_solr_adder'] = adder
-                        updates[value] = (boost_values(obj, data), data)
-                        processed += 1
-                        cpi.next()
-                else:
-                    log('missing data, skipping indexing of %r.\n' % obj)
-                if limit and count >= (skip + limit):
-                    break
+
+                if ignore_portal_types and \
+                   obj.portal_type in ignore_portal_types:
+                    continue
+
+                if (only_portal_types and \
+                    obj.portal_type in only_portal_types) or \
+                    not only_portal_types:
+
+                    data, missing = proc.getData(obj)
+                    prepareData(data)
+                    if not missing:
+                        value = data.get(key, None)
+                        if value is not None:
+                            log('indexing %r\n' % obj)
+                            pt = data.get('portal_type', 'default')
+                            adder = queryAdapter(obj, ISolrAddHandler, name=pt)
+                            if adder is None:
+                                adder = DefaultAdder(obj)
+                            data['_solr_adder'] = adder
+                            updates[value] = (boost_values(obj, data), data)
+                            processed += 1
+                            cpi.next()
+                    else:
+                        log('missing data, skipping indexing of %r.\n' % obj)
+                    if limit and count >= (skip + limit):
+                        break
         checkPoint()
         conn.commit()
         log('solr index rebuilt.\n')

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -110,6 +110,58 @@ class SolrMaintenanceTests(SolrTestCase):
         self.assertEqual(len(log), 3)
         self.assertEqual(numFound(self.search()), 8)
 
+    def testReindexPortalTypesParameters(self):
+        maintenance = self.portal.unrestrictedTraverse('solr-maintenance')
+        # initially the solr index should be empty
+        self.assertEqual(numFound(self.search()), 0)
+
+        ## first test the only_portal_types parameter
+        maintenance.reindex(only_portal_types=[])
+        self.assertEqual(numFound(self.search()), 8)
+        maintenance.clear()
+
+        maintenance.reindex(only_portal_types=['Folder'])
+        self.assertEqual(numFound(self.search()), 4)
+        maintenance.clear()
+
+        maintenance.reindex(only_portal_types=['Folder', 'Collection'])
+        self.assertEqual(numFound(self.search()), 6)
+        maintenance.clear()
+
+        maintenance.reindex(
+            only_portal_types=['Folder', 'Collection', 'NotExistingPortalType']
+        )
+        self.assertEqual(numFound(self.search()), 6)
+        maintenance.clear()
+
+        ## then the ignore_portal_types
+        maintenance.reindex(ignore_portal_types=[])
+        self.assertEqual(numFound(self.search()), 8)
+        maintenance.clear()
+
+        maintenance.reindex(ignore_portal_types=['Folder'])
+        self.assertEqual(numFound(self.search()), 4)
+        maintenance.clear()
+
+        maintenance.reindex(ignore_portal_types=['Folder', 'Collection'])
+        self.assertEqual(numFound(self.search()), 2)
+        maintenance.clear()
+
+        maintenance.reindex(
+            ignore_portal_types=['Folder', 'Collection',
+                                 'NotExistingPortalType']
+        )
+        self.assertEqual(numFound(self.search()), 2)
+        maintenance.clear()
+
+        ## and then both, which is not supported
+        msg = maintenance.reindex(ignore_portal_types=['Collection'],
+                                  only_portal_types=['Folder'])
+        self.assertEquals(
+            msg,
+            'It is not possible to combine ignore_portal_types with ' \
+            'only_portal_types')
+
     def testPartialReindex(self):
         maintenance = self.portal.unrestrictedTraverse('news/solr-maintenance')
         # initially the solr index should be empty


### PR DESCRIPTION
Here is an enhancement to the maintenance_view to add either a list of portal types to ignore on reindex, or restrict the reindex to only a list of given portal_types. This was very useful in our use case to fasten reindex on large databases, where index changes were valid only for certain portal types.