### PR TITLE
Make suggest search work when entering multiple search terms 

### DIFF
--- a/src/collective/solr/skins/solr_site_search/livesearch_reply.py
+++ b/src/collective/solr/skins/solr_site_search/livesearch_reply.py
@@ -62,8 +62,7 @@ multispace = u'\u3000'.encode('utf-8')
 for char in ('?', '-', '+', '*', multispace):
     q = q.replace(char, ' ')
 r = q.split()
-r = " AND ".join(r)
-r = quote_bad_chars(r)+'*'
+r = " AND ".join([quote_bad_chars(x) + "*" for x in r])
 searchterms = url_quote_plus(r)
 
 site_encoding = context.plone_utils.getSiteEncoding()

--- a/src/collective/solr/tests/test_utils.py
+++ b/src/collective/solr/tests/test_utils.py
@@ -8,6 +8,7 @@ from collective.solr.utils import isSimpleTerm
 from collective.solr.utils import isWildCard
 from collective.solr.utils import padResults
 from collective.solr.utils import prepareData
+from collective.solr.utils import prepare_wildcard
 from collective.solr.utils import setupTranslationMap
 from collective.solr.utils import splitSimpleSearch
 from unittest import TestCase
@@ -134,6 +135,22 @@ class UtilsTests(TestCase):
         # other characters might be meaningful in solr, but we don't
         # distinguish them properly (yet)
         self.assertFalse(isWildCard('foo#?'))
+
+    def testPrepareWildcard(self):
+        self.assertEqual(prepare_wildcard("Foo"), "foo")
+        self.assertEqual(prepare_wildcard("and"), "and")
+        self.assertEqual(prepare_wildcard("or"), "or")
+        self.assertEqual(prepare_wildcard("not"), "not")
+        self.assertEqual(prepare_wildcard("Foo and bar"), "foo and bar")
+        self.assertEqual(prepare_wildcard("Foo AND Bar"), "foo AND bar")
+        self.assertEqual(prepare_wildcard("FOO AND NOT BAR"),
+                         "foo AND NOT bar")
+        self.assertEqual(prepare_wildcard("Foo OR Bar"),
+                         "foo OR bar")
+        self.assertEqual(prepare_wildcard("FOO OR NOT BAR"),
+                         "foo OR NOT bar")
+        self.assertEqual(prepare_wildcard("FOO AND BAR OR FOO AND NOT BAR"),
+                         "foo AND bar OR foo AND NOT bar")
 
 
 class TranslationTests(TestCase):

--- a/src/collective/solr/utils.py
+++ b/src/collective/solr/utils.py
@@ -66,6 +66,8 @@ def prepareData(data):
 
 
 simpleTerm = compile(r'^[\w\d]+$', UNICODE)
+
+
 def isSimpleTerm(term):
     if isinstance(term, str):
         term = unicode(term, 'utf-8', 'ignore')
@@ -79,6 +81,8 @@ def isSimpleTerm(term):
 operators = compile(r'(.*)\s+(AND|OR|NOT)\s+', UNICODE)
 simpleCharacters = compile(r'^[\w\d\?\*\s]+$', UNICODE)
 is_digit = compile('\d', UNICODE)
+
+
 def isSimpleSearch(term):
     term = term.strip()
     if isinstance(term, str):
@@ -130,6 +134,8 @@ def splitSimpleSearch(term):
 
 
 wildCard = compile(r'^[\w\d\s*?]*[*?]+[\w\d\s*?]*$', UNICODE)
+
+
 def isWildCard(term):
     if isinstance(term, str):
         term = unicode(term, 'utf-8', 'ignore')
@@ -145,17 +151,17 @@ def prepare_wildcard(value):
     if not isinstance(value, unicode):
         value = unicode(value, 'utf-8', 'ignore')
 
-    value = str(unidecode(value).lower())
+    value = str(unidecode(value))
 
-    # keywords like "AND" and "OR" must not be lowercased, otherwise Solr
-    # will interpret them as search terms.
-    # Re-capitalizing them in the lowercased value might incorrectly capitalize
-    # actual search terms, but this erroneous behaviour is both difficult to provoke
-    # and probably harmless in most cases.
-    value = value.replace(" and ", " AND ")
-    value = value.replace(" or ", " OR ")
-
-    return value
+    # boolean operators must not be lowercased, otherwise Solr will interpret
+    # them as search terms. So we split the search term into tokens and
+    # lowercase only the non-operator parts.
+    parts = []
+    for item in value.split():
+        parts.append(item.lower()
+                     if item not in ("AND", "OR", "NOT")
+                     else item)
+    return " ".join(parts)
 
 
 def findObjects(origin):

--- a/src/collective/solr/utils.py
+++ b/src/collective/solr/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from string import maketrans
 from re import compile, UNICODE
 
@@ -67,8 +66,6 @@ def prepareData(data):
 
 
 simpleTerm = compile(r'^[\w\d]+$', UNICODE)
-
-
 def isSimpleTerm(term):
     if isinstance(term, str):
         term = unicode(term, 'utf-8', 'ignore')
@@ -82,8 +79,6 @@ def isSimpleTerm(term):
 operators = compile(r'(.*)\s+(AND|OR|NOT)\s+', UNICODE)
 simpleCharacters = compile(r'^[\w\d\?\*\s]+$', UNICODE)
 is_digit = compile('\d', UNICODE)
-
-
 def isSimpleSearch(term):
     term = term.strip()
     if isinstance(term, str):
@@ -135,8 +130,6 @@ def splitSimpleSearch(term):
 
 
 wildCard = compile(r'^[\w\d\s*?]*[*?]+[\w\d\s*?]*$', UNICODE)
-
-
 def isWildCard(term):
     if isinstance(term, str):
         term = unicode(term, 'utf-8', 'ignore')
@@ -151,7 +144,18 @@ def prepare_wildcard(value):
     # unidecode will produce the same results
     if not isinstance(value, unicode):
         value = unicode(value, 'utf-8', 'ignore')
-    return str(unidecode(value).lower())
+
+    value = str(unidecode(value).lower())
+
+    # keywords like "AND" and "OR" must not be lowercased, otherwise Solr
+    # will interpret them as search terms.
+    # Re-capitalizing them in the lowercased value might incorrectly capitalize
+    # actual search terms, but this erroneous behaviour is both difficult to provoke
+    # and probably harmless in most cases.
+    value = value.replace(" and ", " AND ")
+    value = value.replace(" or ", " OR ")
+
+    return value
 
 
 def findObjects(origin):


### PR DESCRIPTION
When entering multiple search terms into the live search field, they are joined together with " AND ". Later in the process, everything is lowercased, including the "AND". Thus, Solr no longer recognizes it as a boolean operator but as an additional search term. 