### PR TITLE
Translation & Rendering in Plone 5 Fix

### DIFF
--- a/src/collective/solr/browser/searchbox.pt
+++ b/src/collective/solr/browser/searchbox.pt
@@ -15,6 +15,7 @@
                title="Search Site"
                accesskey="4"
                i18n:attributes="title title_search_title;"
+               tal:attributes="value request/SearchableText|nothing;"
                class="searchPage form-control" />
 
         <input class="searchButton"

--- a/src/collective/solr/browser/searchbox.pt
+++ b/src/collective/solr/browser/searchbox.pt
@@ -14,10 +14,8 @@
                value=""
                title="Search Site"
                accesskey="4"
-               i18n:attributes="title title_search_site;"
-               tal:attributes="value request/SearchableText|nothing;
-                               id view/search_input_id"
-               class="inputLabel" />
+               i18n:attributes="title title_search_title;"
+               class="searchPage form-control" />
 
         <input class="searchButton"
                type="submit"


### PR DESCRIPTION
Translation of the Search Box label fixed.
Attribute value deleted. Plone 5 do not render the Search Box with it. 