### PR TITLE
Randomports

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,20 @@ Example::
             <solr:connection host="localhost" port="8983" base="/solr/plone"/>
        </configure>
 
+Testing
+-------
+
+collective.solr provides a testing layer that you can use in your projects. It contains one assumption at the momment:
+- It assumes that the script for starting solr is called solr-instance
+- It assumes you are running a single core and have the ping handler configured on /admin/ping (This is the default)
+
+Out of the box, it will assign solr to a unused random port.
+For multi core setups, you can customize the layer by Subclassing it and setting the proper full url to the attribute admin_ping_url::
+
+    class MySolrLayer(SolrLayer):
+        def __init__(self, *args, **kwargs):
+            super(MySolrLayer, self).__init__(*args, **kwargs)
+            self.admin_ping_url = '{0}/catalog/admin/ping'.format(self.solr_url)
 
 
 Current Project Status

--- a/base.cfg
+++ b/base.cfg
@@ -11,6 +11,10 @@ parts +=
 develop = .
 
 
+auto-checkout =
+    collective.recipe.solrinstance
+
+
 [instance]
 recipe = plone.recipe.zope2instance
 user = admin:admin
@@ -66,3 +70,7 @@ eggs = zest.releaser
 recipe = collective.recipe.sphinxbuilder
 source = ${buildout:directory}/docs/source
 build = ${buildout:directory}/docs
+
+
+[sources]
+collective.recipe.solrinstance = git https://github.com/collective/collective.recipe.solrinstance branch=better_port

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,28 +1,7 @@
 [buildout]
 extends =
-    buildout/base.cfg
-    buildout/solr.cfg
-parts +=
-    autopep8
-    releaser
-
-extensions = mr.developer
-
-[solr-download]
-recipe = hexagonit.recipe.download
-strip-top-level-dir = true
-url = https://archive.apache.org/dist/lucene/solr/4.10.2/solr-4.10.2.tgz
-md5sum = a24f73f70e3fcf6aa8fda67444981f78
-
-[autopep8]
-recipe = zc.recipe.egg
-eggs = autopep8
-
-[releaser]
-recipe = zc.recipe.egg
-eggs =
-    zest.releaser
-    zest.pocompile
-
-[sources]
-collective.recipe.solrinstance = git https://github.com/collective/collective.recipe.solrinstance branch=better-port
+    base.cfg
+    plone-4.3.x.cfg
+    solr.cfg
+    solr-4.10.x.cfg
+    versions.cfg

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,7 +1,28 @@
 [buildout]
 extends =
-    base.cfg
-    plone-4.3.x.cfg
-    solr.cfg
-    solr-4.10.x.cfg
-    versions.cfg
+    buildout/base.cfg
+    buildout/solr.cfg
+parts +=
+    autopep8
+    releaser
+
+extensions = mr.developer
+
+[solr-download]
+recipe = hexagonit.recipe.download
+strip-top-level-dir = true
+url = https://archive.apache.org/dist/lucene/solr/4.10.2/solr-4.10.2.tgz
+md5sum = a24f73f70e3fcf6aa8fda67444981f78
+
+[autopep8]
+recipe = zc.recipe.egg
+eggs = autopep8
+
+[releaser]
+recipe = zc.recipe.egg
+eggs =
+    zest.releaser
+    zest.pocompile
+
+[sources]
+collective.recipe.solrinstance = git https://github.com/collective/collective.recipe.solrinstance branch=better-port

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-4.1.1 (unreleased)
+4.2.0 (unreleased)
 ------------------
 
 - solr.cfg has been moved from https://github.com/collective/collective.solr/raw/master/buildout/solr.cfg to https://github.com/collective/collective.solr/raw/master/solr.cfg.

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'plone.app.vocabularies',
         'plone.browserlayer',
         'plone.indexer',
+        'psutil',
         'setuptools',
         'transaction',
         'zope.component',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os.path
 from setuptools import setup
 from setuptools import find_packages
 
-version = '4.1.1.dev0'
+version = '4.2.0.dev0'
 long_description = \
     open("README.rst").read() + '\n' + \
     open(os.path.join('docs', 'CHANGES.rst')).read() + \

--- a/solr.cfg
+++ b/solr.cfg
@@ -18,6 +18,7 @@ strip-top-level-dir = true
 
 [solr-instance]
 recipe = collective.recipe.solrinstance
+solr-version = 4
 solr-location = ${solr-download:location}
 host = ${settings:solr-host}
 port = ${settings:solr-port}
@@ -28,7 +29,7 @@ section-name = SOLR
 unique-key = UID
 logdir = ${buildout:directory}/var/solr
 default-search-field = default
-default-operator = and
+default-operator = AND
 unique-key = UID
 java_opts =
   -Dcom.sun.management.jmxremote

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 from Products.CMFCore.utils import getToolByName
 from collective.solr.configlet import SolrControlPanelAdapter
 from collective.solr.utils import activate
@@ -106,7 +105,8 @@ class SolrLayer(Layer):
                 cwd=BUILDOUT_DIR
             )
             sys.stdout.write('Solr Instance could not be started !!!')
-            raise Exception("Unable to start solr", http_error)
+            raise Exception("Unable to start solr, %i %s", http_error.code,
+                            http_error.msg)
 
     def tearDown(self):
         """Stop Solr.

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -132,6 +132,12 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
         super(CollectiveSolrLayer, self).tearDown()
         SolrLayer.tearDown(self)
 
+    def setUpZope(self, app, configurationContext):
+        import collective.solr
+        xmlconfig.file('configure.zcml',
+                       collective.solr,
+                       context=configurationContext)
+
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'collective.solr:search')
         solr_settings = SolrControlPanelAdapter(portal)
@@ -149,13 +155,13 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
 class LegacyCollectiveSolrLayer(CollectiveSolrLayer):
 
     def setUpZope(self, app, configurationContext):
+        super(LegacyCollectiveSolrLayer, self).setUpZope(
+            app,
+            configurationContext
+        )
         import collective.indexing
         xmlconfig.file('configure.zcml',
                        collective.indexing,
-                       context=configurationContext)
-        import collective.solr
-        xmlconfig.file('configure.zcml',
-                       collective.solr,
                        context=configurationContext)
         installProduct(app, 'collective.indexing')
 

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -105,8 +105,11 @@ class SolrLayer(Layer):
                 cwd=BUILDOUT_DIR
             )
             sys.stdout.write('Solr Instance could not be started !!!')
-            raise Exception("Unable to start solr, %i %s", http_error.code,
-                            http_error.msg)
+            try:
+                raise Exception("Unable to start solr, %i %s", http_error.code,
+                                http_error.msg)
+            except AttributeError:
+                raise http_error
 
     def tearDown(self):
         """Stop Solr.

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -88,7 +88,6 @@ class SolrLayer(Layer):
             cwd=BUILDOUT_DIR
         )
 
-
 SOLR_FIXTURE = SolrLayer()
 
 
@@ -133,17 +132,6 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
         super(CollectiveSolrLayer, self).tearDown()
         SolrLayer.tearDown(self)
 
-    def setUpZope(self, app, configurationContext):
-        import collective.indexing
-        xmlconfig.file('configure.zcml',
-                       collective.indexing,
-                       context=configurationContext)
-        import collective.solr
-        xmlconfig.file('configure.zcml',
-                       collective.solr,
-                       context=configurationContext)
-        installProduct(app, 'collective.indexing')
-
     def setUpPloneSite(self, portal):
         applyProfile(portal, 'collective.solr:search')
         solr_settings = SolrControlPanelAdapter(portal)
@@ -159,6 +147,17 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
 
 
 class LegacyCollectiveSolrLayer(CollectiveSolrLayer):
+
+    def setUpZope(self, app, configurationContext):
+        import collective.indexing
+        xmlconfig.file('configure.zcml',
+                       collective.indexing,
+                       context=configurationContext)
+        import collective.solr
+        xmlconfig.file('configure.zcml',
+                       collective.solr,
+                       context=configurationContext)
+        installProduct(app, 'collective.indexing')
 
     def setUpPloneSite(self, portal):
         super(LegacyCollectiveSolrLayer, self).setUpPloneSite(portal)

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -39,7 +39,7 @@ class SolrLayer(Layer):
             name='Solr Layer',
             module=None,
             solr_host='localhost',
-            solr_port='RANDOM',
+            solr_port=8983,
             solr_base='/solr'):
 
         super(SolrLayer, self).__init__(bases, name, module)
@@ -134,7 +134,7 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
             module=None,
             solr_active=False,
             solr_host='localhost',
-            solr_port='RANDOM',
+            solr_port=8983,
             solr_base='/solr'):
         super(CollectiveSolrLayer, self).__init__(
             bases,

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -70,6 +70,10 @@ class SolrLayer(Layer):
     def setUp(self):
         """Start Solr and poll until it is up and running.
         """
+        status = subprocess.check_output(['./solr-instance', 'status'],
+                                         cwd=BUILDOUT_DIR)
+        if status != 'Solr not running.\n':
+            raise Exception("Sor is already running: %s", status)
         self.proc = subprocess.call(
             './solr-instance start -Djetty.port={0}'.format(self.solr_port),
             shell=True,

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -70,7 +70,7 @@ class SolrLayer(Layer):
         """Start Solr and poll until it is up and running.
         """
         self.proc = subprocess.call(
-            './solr-instance start',
+            './solr-instance start -Djetty.port={0}'.format(self.solr_port),
             shell=True,
             close_fds=True,
             cwd=BUILDOUT_DIR
@@ -94,6 +94,7 @@ class SolrLayer(Layer):
                     cwd=BUILDOUT_DIR
                 )
                 sys.stdout.write('Solr Instance could not be started !!!')
+                raise Exception("Unable to start solr")
 
     def tearDown(self):
         """Stop Solr.
@@ -121,17 +122,14 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
             module=None,
             solr_active=False,
             solr_host='localhost',
-            solr_port=8983,
+            solr_port='RANDOM',
             solr_base='/solr'):
         super(CollectiveSolrLayer, self).__init__(bases, name, module)
         self.solr_active = solr_active
-        self.solr_host = solr_host
-        self.solr_port = solr_port
-        self.solr_base = solr_base
         self.solr_url = 'http://{0}:{1}{2}'.format(
-            solr_host,
-            solr_port,
-            solr_base
+            self.solr_host,
+            self.solr_port,
+            self.solr_base
         )
 
     def setUp(self):
@@ -165,7 +163,7 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
     def tearDownPloneSite(self, portal):
         solr_settings = SolrControlPanelAdapter(portal)
         solr_settings.setActive(False)
-        solr_settings.setPort(8983)
+        solr_settings.setPort(self.solr_port)
         solr_settings.setBase('/solr')
 
 

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -96,8 +96,6 @@ class SolrLayer(Layer):
                     raise Exception("Solr is not configured correctly. "
                                     "If you are using a multicore setup, "
                                     "refer to the documentation")
-                if getattr(http_error, 'code', 200) == 500:
-                    import pdb;pdb.set_trace()
                 sleep(3)
                 sys.stdout.write('.')
             if i == 9:

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -47,10 +47,10 @@ class SolrLayer(Layer):
         if solr_port == 'RANDOM':
             solr_port = self._find_available_solr_port()
 
-        self.solr_host = solr_host
-        self.solr_port = solr_port
-        self.solr_base = solr_base
-        self.solr_url = 'http://{0}:{1}{2}'.format(
+        self['solr_host'] = solr_host
+        self['solr_port'] = solr_port
+        self['solr_base'] = solr_base
+        self['solr_url'] = 'http://{0}:{1}{2}'.format(
             solr_host,
             solr_port,
             solr_base
@@ -71,7 +71,7 @@ class SolrLayer(Layer):
     def _startSolr(self):
         print 'start again'
         self.proc = subprocess.call(
-            './solr-instance start -Djetty.port={0}'.format(self.solr_port),
+            './solr-instance start -Djetty.port={0}'.format(self['solr_port']),
             shell=True,
             close_fds=True,
             cwd=BUILDOUT_DIR
@@ -101,12 +101,12 @@ class SolrLayer(Layer):
                     psutil.Process(pid)
                 except psutil.NoSuchProcess:
                     self._startSolr()
-                solr_ping_url = self.solr_url + '/admin/ping'
+                solr_ping_url = self['solr_url'] + '/admin/ping'
                 result = urllib2.urlopen(solr_ping_url)
                 if result.code == 200:
                     if '<str name="status">OK</str>' in result.read():
                         os.environ['SOLR_HOST'] = '{0}:{1}'.format(
-                            self.solr_host, self.solr_port)
+                            self['solr_host'], self['solr_port'])
                         running = True
                         break
             except urllib2.URLError, http_error:
@@ -162,11 +162,11 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
             solr_host=solr_host,
             solr_port=solr_port,
             solr_base=solr_base)
-        self.solr_active = solr_active
-        self.solr_url = 'http://{0}:{1}{2}'.format(
-            self.solr_host,
-            self.solr_port,
-            self.solr_base
+        self['solr_active'] = solr_active
+        self['solr_url'] = 'http://{0}:{1}{2}'.format(
+            self['solr_host'],
+            self['solr_port'],
+            self['solr_base']
         )
 
     def setUp(self):
@@ -194,20 +194,20 @@ class CollectiveSolrLayer(PloneSandboxLayer, SolrLayer):
         applyProfile(portal, 'collective.solr:search')
         self.updateSolrSettings(portal)
         solr_settings = SolrControlPanelAdapter(portal)
-        solr_settings.setActive(self.solr_active)
-        solr_settings.setPort(self.solr_port)
-        solr_settings.setBase(self.solr_base)
+        solr_settings.setActive(self['solr_active'])
+        solr_settings.setPort(self['solr_port'])
+        solr_settings.setBase(self['solr_base'])
 
     def updateSolrSettings(self, portal):
         solr_settings = SolrControlPanelAdapter(portal)
-        solr_settings.setActive(self.solr_active)
-        solr_settings.setPort(self.solr_port)
-        solr_settings.setBase(self.solr_base)
+        solr_settings.setActive(self['solr_active'])
+        solr_settings.setPort(self['solr_port'])
+        solr_settings.setBase(self['solr_base'])
 
     def tearDownPloneSite(self, portal):
         solr_settings = SolrControlPanelAdapter(portal)
         solr_settings.setActive(False)
-        solr_settings.setPort(self.solr_port)
+        solr_settings.setPort(self['solr_port'])
         solr_settings.setBase('/solr')
 
 

--- a/src/collective/solr/tests/configlet.txt
+++ b/src/collective/solr/tests/configlet.txt
@@ -16,8 +16,9 @@ active without *having* it active.
     False
     >>> config.host
     '127.0.0.1'
-    >>> config.port
-    8983
+    >>> random_port = config.port
+    >>> 1024 < random_port < 2<<16
+    True
     >>> config.base
     '/solr'
     >>> config.async
@@ -191,7 +192,7 @@ parameters from the complete list of Solr indexes, provided that we use the
 correct host and port:
 
     >>> browser.getControl(name='form.host').value = '127.0.0.1'
-    >>> browser.getControl(name='form.port').value = '8983'
+    >>> browser.getControl(name='form.port').value = str(random_port)
     >>> browser.getControl(name="form.actions.save").click()
 
     >>> browser.getControl(name='form.filter_queries.add').click()

--- a/src/collective/solr/tests/errors.txt
+++ b/src/collective/solr/tests/errors.txt
@@ -118,7 +118,7 @@ other tests:
 
   >>> getUtility(ISolrConnectionManager).setHost(active=False, port=port)
   >>> import urllib
-  >>> urllib.urlopen('http://127.0.0.1:55555')
+  >>> urllib.urlopen('http://127.0.0.1:55555').read()
   Traceback (most recent call last):
   IOError: ...
   >>> urllib.urlopen('http://127.0.0.1:55555')

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -409,6 +409,8 @@ class SolrServerTests(TestCase):
         fields.remove('default')
         # remove field not defined for a folder
         fields.remove('getRemoteUrl')
+        # remove field which is only for some form of better accid
+        fields.remove('_version_')
         proc = SolrIndexProcessor(manager)
         # without explicit attributes all data should be returned
         data, missing = proc.getData(self.folder)

--- a/src/collective/solr/tests/test_test_layers.py
+++ b/src/collective/solr/tests/test_test_layers.py
@@ -7,16 +7,16 @@ import socket
 class TestLayerTests(TestCase):
 
     expected_random_values = [
-        5485,
-        29409,
-        10547,
-        21141,
-        28218,
-        3939,
-        22352,
-        20724,
-        19392,
-        9443]
+        10090,
+        58709,
+        20377,
+        41907,
+        56288,
+        6948,
+        44367,
+        41059,
+        38351,
+        18133]
 
     def testRandomPorts(self):
         random.seed('Reproducable randomness')

--- a/src/collective/solr/tests/test_test_layers.py
+++ b/src/collective/solr/tests/test_test_layers.py
@@ -21,18 +21,18 @@ class TestLayerTests(TestCase):
     def testRandomPorts(self):
         random.seed('Reproducable randomness')
         for random_port in self.expected_random_values:
-            layer = SolrLayer()
+            layer = SolrLayer(solr_port='RANDOM')
             self.assertEqual(random_port, layer.solr_port)
 
     def testRandomPortsSkipUsedPorts(self):
         random.seed('Reproducable randomness')
         for random_port in self.expected_random_values[:8]:
-            layer = SolrLayer()
+            layer = SolrLayer(solr_port='RANDOM')
             self.assertEqual(random_port, layer.solr_port)
         a_socket = socket.socket(socket.AF_INET)
         try:
             a_socket.bind(('127.0.0.1', self.expected_random_values[8]))
-            layer = SolrLayer()
+            layer = SolrLayer(solr_port='RANDOM')
             self.assertEqual(self.expected_random_values[9], layer.solr_port)
         finally:
             a_socket.close()

--- a/src/collective/solr/tests/test_test_layers.py
+++ b/src/collective/solr/tests/test_test_layers.py
@@ -1,0 +1,38 @@
+from collective.solr.testing import SolrLayer
+from unittest import TestCase
+import random
+import socket
+
+
+class TestLayerTests(TestCase):
+
+    expected_random_values = [
+        5485,
+        29409,
+        10547,
+        21141,
+        28218,
+        3939,
+        22352,
+        20724,
+        19392,
+        9443]
+
+    def testRandomPorts(self):
+        random.seed('Reproducable randomness')
+        for random_port in self.expected_random_values:
+            layer = SolrLayer()
+            self.assertEqual(random_port, layer.solr_port)
+
+    def testRandomPortsSkipUsedPorts(self):
+        random.seed('Reproducable randomness')
+        for random_port in self.expected_random_values[:8]:
+            layer = SolrLayer()
+            self.assertEqual(random_port, layer.solr_port)
+        a_socket = socket.socket(socket.AF_INET)
+        try:
+            a_socket.bind(('127.0.0.1', self.expected_random_values[8]))
+            layer = SolrLayer()
+            self.assertEqual(self.expected_random_values[9], layer.solr_port)
+        finally:
+            a_socket.close()


### PR DESCRIPTION
This PR would change the standard behavior of its Solr Layer to use a random port by default.
It requires a source checkout of collective.recipe.solrinstance.