### PR TITLE
Port atomic update feature from ftw.solr into collective.solr.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,19 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
+- Ported atomic updates from ftw.solr.
+  This requires you need to update your solr config, load the new solr config and
+  do a full reindex. Please also note
+  [mathias.leimgruber]
+
+  - Added support for atomic updates.
+    This means whenever possible, only the necessary / specified attributes get updated in Solr, and more importantly, re-indexed by Plone's indexers.
+    IMPORTANT: This requires the Solr instance to have an <updateLog/> configured in
+    solrconfig.xml and the schema needs to contain a _version_ field.
+    Further all your indexes configured in solr.cfg needs the stored:true attribute.
+    See http://wiki.apache.org/solr/Atomic_Updates for details.
+    [lgraf]
+
 - solr.cfg has been moved from https://github.com/collective/collective.solr/raw/master/buildout/solr.cfg to https://github.com/collective/collective.solr/raw/master/solr.cfg.
   [timo]
 

--- a/solr.cfg
+++ b/solr.cfg
@@ -40,12 +40,15 @@ java_opts =
   -Xms${settings:solr-min-ram}
   -Xmx${settings:solr-max-ram}
 
+additional-solrconfig =
+    <updateLog/>
+
 index =
     name:allowedRolesAndUsers   type:string stored:true multivalued:true
     name:created                type:date stored:true
     name:Creator                type:string stored:true
     name:Date                   type:date stored:true
-    name:default                type:text indexed:true stored:true multivalued:true
+    name:default                type:text indexed:true stored:false multivalued:true
     name:Description            type:text copyfield:default stored:true
     name:effective              type:date stored:true
     name:exclude_from_nav       type:boolean indexed:false stored:true

--- a/solr.cfg
+++ b/solr.cfg
@@ -39,12 +39,13 @@ java_opts =
   -server
   -Xms${settings:solr-min-ram}
   -Xmx${settings:solr-max-ram}
+
 index =
-    name:allowedRolesAndUsers   type:string stored:false multivalued:true
+    name:allowedRolesAndUsers   type:string stored:true multivalued:true
     name:created                type:date stored:true
     name:Creator                type:string stored:true
     name:Date                   type:date stored:true
-    name:default                type:text indexed:true stored:false multivalued:true
+    name:default                type:text indexed:true stored:true multivalued:true
     name:Description            type:text copyfield:default stored:true
     name:effective              type:date stored:true
     name:exclude_from_nav       type:boolean indexed:false stored:true
@@ -55,16 +56,17 @@ index =
     name:is_folderish           type:boolean stored:true
     name:Language               type:string stored:true
     name:modified               type:date stored:true
-    name:object_provides        type:string stored:false multivalued:true
-    name:path_depth             type:integer indexed:true stored:false
-    name:path_parents           type:string indexed:true stored:false multivalued:true
+    name:object_provides        type:string stored:true multivalued:true
+    name:path_depth             type:integer indexed:true stored:true
+    name:path_parents           type:string indexed:true stored:true multivalued:true
     name:path_string            type:string indexed:false stored:true
     name:portal_type            type:string stored:true
     name:review_state           type:string stored:true
-    name:SearchableText         type:text copyfield:default stored:false
-    name:searchwords            type:string stored:false multivalued:true
-    name:showinsearch           type:boolean stored:false
+    name:SearchableText         type:text copyfield:default stored:true
+    name:searchwords            type:string stored:true multivalued:true
+    name:showinsearch           type:boolean stored:true
     name:Subject                type:string copyfield:default stored:true multivalued:true
     name:Title                  type:text copyfield:default stored:true
     name:Type                   type:string stored:true
     name:UID                    type:string stored:true required:true
+    name:_version_              type:long indexed:true stored:true

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -195,6 +195,12 @@ class SolrIndexProcessor(object):
                 attributes = set(schema.keys()).intersection(attributes)
                 if not attributes:
                     return
+
+                if uniqueKey not in attributes:
+                    # The uniqueKey is required in order to identify the
+                    # document when doing atomic updates.
+                    attributes.add(uniqueKey)
+
             data, missing = self.getData(obj, attributes=attributes)
             if not data:
                 return          # don't index with no data...

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -173,13 +173,14 @@ class SolrIndexProcessor(object):
         self.manager = manager
 
     def index(self, obj, attributes=None):
+        """Index the specified attributes for obj using atomic updates, or all
+        of them if `attributes` is `None`.
+        Also make sure the `uniqueKey` is part of attributes, and passing the
+        attributes to the self.getData() call to avoid causing Plone to index
+        all fields instead of just the necessary ones.
+        """
         conn = self.getConnection()
         if conn is not None and ICheckIndexable(obj)():
-            # unfortunately with current versions of solr we need to provide
-            # data for _all_ fields during an <add> -- partial updates aren't
-            # supported (see https://issues.apache.org/jira/browse/SOLR-139)
-            # however, the reindexing can be skipped if none of the given
-            # attributes match existing solr indexes...
             schema = self.manager.getSchema()
             if schema is None:
                 msg = 'unable to fetch schema, skipping indexing of %r'
@@ -194,7 +195,7 @@ class SolrIndexProcessor(object):
                 attributes = set(schema.keys()).intersection(attributes)
                 if not attributes:
                     return
-            data, missing = self.getData(obj)
+            data, missing = self.getData(obj, attributes=attributes)
             if not data:
                 return          # don't index with no data...
             prepareData(data)

--- a/src/collective/solr/manager.py
+++ b/src/collective/solr/manager.py
@@ -135,7 +135,7 @@ class SolrConnectionManager(object):
                 logger.debug('getting schema from solr')
                 self.setSearchTimeout()
                 try:
-                    schema = conn.getSchema()
+                    schema = conn.get_schema()
                     setLocal('schema', schema)
                 except (error, CannotSendRequest, ResponseNotReady):
                     logger.exception('exception while getting schema')

--- a/src/collective/solr/tests/data/add_request.txt
+++ b/src/collective/solr/tests/data/add_request.txt
@@ -1,7 +1,7 @@
 POST /solr/update HTTP/1.1
 Host: localhost
 Accept-Encoding: identity
-Content-Length: 92
+Content-Length: 105
 Content-Type: text/xml; charset=utf-8
 
-<add><doc><field name="id">500</field><field name="name">python test doc</field></doc></add>
+<add><doc><field name="id">500</field><field name="name" update="set">python test doc</field></doc></add>

--- a/src/collective/solr/tests/data/add_request_with_boost_values.txt
+++ b/src/collective/solr/tests/data/add_request_with_boost_values.txt
@@ -1,7 +1,7 @@
 POST /solr/update HTTP/1.1
 Host: localhost
 Accept-Encoding: identity
-Content-Length: 124
+Content-Length: 125
 Content-Type: text/xml; charset=utf-8
 
-<add><doc boost="2"><field name="id" boost="0.5">500</field><field name="name" boost="5">python test doc</field></doc></add>
+<add><doc boost="2"><field name="id">500</field><field name="name" boost="5" update="set">python test doc</field></doc></add>

--- a/src/collective/solr/tests/data/add_response.txt
+++ b/src/collective/solr/tests/data/add_response.txt
@@ -1,10 +1,10 @@
 HTTP/1.1 200 OK
 Content-Type: text/xml; charset=utf-8
-Content-Length: 147
+Content-Length: 172
 Server: Jetty(6.1.3)
 
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
 <lst name="responseHeader"><int name="status">0</int><int name="QTime">4</int></lst>
+<uniqueKey>id</uniqueKey>
 </response>
-

--- a/src/collective/solr/tests/data/dummy_response.txt
+++ b/src/collective/solr/tests/data/dummy_response.txt
@@ -1,9 +1,10 @@
 HTTP/1.1 200 OK
 Content-Type: text/xml; charset=utf-8
-Content-Length: 62
+Content-Length: 89
 Server: Jetty(6.1.3)
 
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
+<uniqueKey>UID</uniqueKey>
 </response>
 

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -131,7 +131,8 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required = '<field name="timestamp">1972-05-11T03:45:00.000Z</field>'
+        required = ('<field name="timestamp" update="set">'
+                    '1972-05-11T03:45:00.000Z</field>')
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
     def testDateIndexingWithPythonDateTime(self):
@@ -141,7 +142,8 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required = '<field name="timestamp">1980-09-29T14:02:00.000Z</field>'
+        required = ('<field name="timestamp" update="set">'
+                    '1980-09-29T14:02:00.000Z</field>')
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
     def testDateIndexingWithPythonDate(self):
@@ -151,7 +153,8 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required = '<field name="timestamp">1982-08-05T00:00:00.000Z</field>'
+        required = ('<field name="timestamp" update="set">'
+                    '1982-08-05T00:00:00.000Z</field>')
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
     def testReindexObject(self):
@@ -201,7 +204,7 @@ class QueueIndexerTests(TestCase):
         self.proc.index(foo)
         output = str(output)
         self.assertTrue(
-            output.find('<field name="cat">nerd</field>') > 0,
+            output.find('<field name="cat" update="set">nerd</field>') > 0,
             '"cat" data not found'
         )
         self.assertEqual(output.find('price'), -1, '"price" data found?')
@@ -343,6 +346,11 @@ class ThreadedConnectionTests(TestCase):
         log = []
 
         def runner():
+
+            # fake schema response on solr connection - caches the schema
+            fakehttp(mngr.getConnection(), getData('schema.xml'))
+            mngr.getConnection().get_schema()
+
             fakehttp(mngr.getConnection(), schema)      # fake schema response
             # read and cache the schema
             mngr.getSchema()

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -109,25 +109,20 @@ class QueueIndexerTests(TestCase):
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
         self.assert_(str(output).find(
-            '<field name="price">42.0</field>') > 0, '"price" data not found')
+            '<field name="price" update="set">42.0</field>') > 0,
+            '"price" data not found')
         # then only a subset...
         response = getData('add_response.txt')
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo, attributes=['id', 'name'])
         output = str(output)
         self.assert_(
-            output.find('<field name="name">foo</field>') > 0,
+            output.find('<field name="name" update="set">foo</field>') > 0,
             '"name" data not found'
         )
         # at this point we'd normally check for a partial update:
-        #   self.assertEqual(output.find('price'), -1, '"price" data found?')
-        #   self.assertEqual(output.find('42'), -1, '"price" data found?')
-        # however, until SOLR-139 has been implemented (re)index operations
-        # always need to provide data for all attributes in the schema...
-        self.assert_(
-            output.find('<field name="price">42.0</field>') > 0,
-            '"price" data not found'
-        )
+        self.assertEqual(output.find('price'), -1, '"price" data found?')
+        self.assertEqual(output.find('42'), -1, '"price" data found?')
 
     def testDateIndexing(self):
         foo = Foo(id='zeidler', name='andi', cat='nerd',

--- a/src/collective/solr/tests/test_integration.py
+++ b/src/collective/solr/tests/test_integration.py
@@ -109,6 +109,8 @@ class IndexingTests(TestCase):
     def testIndexObject(self):
         output = []
         connection = self.proc.getConnection()
+        connection.get_schema()  # cache schema to avoid multiple calls
+
         responses = (getData('plone_schema.xml'),
                      getData('commit_response.txt'))
         output = fakehttp(connection, *responses)           # fake responses
@@ -116,7 +118,7 @@ class IndexingTests(TestCase):
         self.assertEqual(self.folder.Title(), 'Foo')
         self.assertEqual(str(output), '', 'reindexed unqueued!')
         commit()                        # indexing happens on commit
-        required = '<field name="Title">Foo</field>'
+        required = '<field name="Title" update="set">Foo</field>'
         self.assertTrue(str(output).find(required) > 0,
                         '"title" data not found')
 

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -214,9 +214,10 @@ class SolrMaintenanceTests(TestCase):
         from Products.PythonScripts.PythonScript import PythonScript
         name = 'solr_boost_index_values'
         self.portal[name] = PythonScript(name)
-        self.portal[name].write("##parameters=data\n"
-                                "return {'': 100} "
-                                "if data['getId'] == 'special' else {}")
+        self.portal[name].write(
+            "##parameters=data\n"
+            "return {'': 100} "
+            "if data.get('getId', '') == 'special' else {}")
         self.folder.invokeFactory('Document', id='dull', title='foo',
                                   description='the bar is missing here')
         self.folder.invokeFactory('Document', id='special', title='bar',
@@ -320,7 +321,7 @@ class SolrErrorHandlingTests(TestCase):
         self.config = getUtility(ISolrConnectionConfig)
         self.port = self.config.port        # remember previous port setting
         self.folder.unmarkCreationFlag()    # stop LinguaPlone from renaming
-        # Prevent collective indexing queues to pile up for folder createion
+        # Prevent collective indexing queues to pile up for folder creation
         commit()
 
     def tearDown(self):
@@ -343,10 +344,14 @@ class SolrErrorHandlingTests(TestCase):
         manager.closeConnection()   # which would trigger a reconnect
         self.folder.processForm(values={'title': 'Bar'})
         commit()                    # indexing (doesn't) happen on commit
-        self.assertEqual(log, ['exception during request %r', log[1],
+
+        # INFO:
+        # Due the "atomic update" feature the indexing mechanism catches the
+        # socket error, instead of the connection.
+        # This also means we do not have the payload sent to solr at this
+        # place.
+        self.assertEqual(log, ['exception during indexing %r', log[1],
                                'exception during request %r', '<commit/>'])
-        self.assertTrue('test_user_1_' in log[1])
-        self.assertTrue('Bar' in log[1])
 
     def testNetworkFailureBeforeSchemaCanBeLoaded(self):
         log = []
@@ -409,6 +414,8 @@ class SolrServerTests(TestCase):
         fields.remove('default')
         # remove field not defined for a folder
         fields.remove('getRemoteUrl')
+        # remove _version_ field
+        fields.remove('_version_')
         proc = SolrIndexProcessor(manager)
         # without explicit attributes all data should be returned
         data, missing = proc.getData(self.folder)

--- a/src/collective/solr/tests/test_solr.py
+++ b/src/collective/solr/tests/test_solr.py
@@ -9,7 +9,13 @@ class TestSolr(TestCase):
     def test_add(self):
         add_request = getData('add_request.txt')
         add_response = getData('add_response.txt')
+
         c = SolrConnection(host='localhost:8983', persistent=True)
+
+        # fake schema response - caches the schema
+        fakehttp(c, getData('schema.xml'))
+        c.get_schema()
+
         output = fakehttp(c, add_response)
         c.add(id='500', name='python test doc')
         res = c.flush()
@@ -30,6 +36,11 @@ class TestSolr(TestCase):
         add_request = getData('add_request_with_boost_values.txt')
         add_response = getData('add_response.txt')
         c = SolrConnection(host='localhost:8983', persistent=True)
+
+        # fake schema response - caches the schema
+        fakehttp(c, getData('schema.xml'))
+        c.get_schema()
+
         output = fakehttp(c, add_response)
         boost = {'': 2, 'id': 0.5, 'name': 5}
         c.add(boost_values=boost, id='500', name='python test doc')


### PR DESCRIPTION
This PR imlements the atomic udpate feature from ftw.solr into collective.solr. 


In order to fully support the atomic update feature introduced in Solr 4 the following changes are required:
1. All fields need in your solr.cfg needs the `stored:true`attribute
2. `<updateLog/>` configured in solrconfig.xml (Supported by collective.receipe.solrinstance 6.0.0b3)
3. A new field:  `_version_`

More details --> http://wiki.apache.org/solr/Atomic_Updates

Example:
Call `solr-maintenance/reindex?idxs:list=Title&idxs:list=Description` on any object.

```
2015/09/15-15:39:12 reindexing solr catalog...
2015/09/15-15:39:12 indexing only ['Title', 'Description'] 
2015/09/15-15:39:12 indexing <Folder at /Plone/downloads>
2015/09/15-15:39:12 indexing <File at /Plone/downloads/file5>
2015/09/15-15:39:12 indexing <File at /Plone/downloads/file4>
2015/09/15-15:39:12 indexing <File at /Plone/downloads/file3>
2015/09/15-15:39:12 indexing <File at /Plone/downloads/file2>
2015/09/15-15:39:12 indexing <File at /Plone/downloads/file1>
2015/09/15-15:39:12 intermediate commit (6 items processed, last batch in 0.024s)...
2015/09/15-15:39:12 solr index rebuilt.
2015/09/15-15:39:12 processed 6 items in 0.055s (0.027s cpu time).
``` 