### PR TITLE
Implement atomic updates with collective.receipe.solrinstance 6.0.0b3

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,19 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
+- Ported atomic updates from ftw.solr.
+  This requires you need to update your solr config, load the new solr config and
+  do a full reindex. Please also note
+  [mathias.leimgruber]
+
+  - Added support for atomic updates.
+    This means whenever possible, only the necessary / specified attributes get updated in Solr, and more importantly, re-indexed by Plone's indexers.
+    IMPORTANT: This requires the Solr instance to have an <updateLog/> configured in
+    solrconfig.xml and the schema needs to contain a _version_ field.
+    Further all your indexes configured in solr.cfg needs the stored:true attribute.
+    See http://wiki.apache.org/solr/Atomic_Updates for details.
+    [lgraf]
+
 - solr.cfg has been moved from https://github.com/collective/collective.solr/raw/master/buildout/solr.cfg to https://github.com/collective/collective.solr/raw/master/solr.cfg.
   [timo]
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,16 +6,9 @@ Changelog
 
 - Ported atomic updates from ftw.solr.
   This requires you need to update your solr config, load the new solr config and
-  do a full reindex. Please also note
+  do a full reindex. For more informations check the "feature" section.
+  The feature was implemented in ftw.solr by [lgraf].
   [mathias.leimgruber]
-
-  - Added support for atomic updates.
-    This means whenever possible, only the necessary / specified attributes get updated in Solr, and more importantly, re-indexed by Plone's indexers.
-    IMPORTANT: This requires the Solr instance to have an <updateLog/> configured in
-    solrconfig.xml and the schema needs to contain a _version_ field.
-    Further all your indexes configured in solr.cfg needs the stored:true attribute.
-    See http://wiki.apache.org/solr/Atomic_Updates for details.
-    [lgraf]
 
 - solr.cfg has been moved from https://github.com/collective/collective.solr/raw/master/buildout/solr.cfg to https://github.com/collective/collective.solr/raw/master/solr.cfg.
   [timo]

--- a/docs/features/atomic_updates.rst
+++ b/docs/features/atomic_updates.rst
@@ -1,0 +1,13 @@
+Partial indexing documents (AtomicUpdates)
+******************************************
+
+This means whenever possible, only the necessary / specified attributes get updated in Solr, and more importantly, re-indexed by Plone's indexers.
+
+With collective.receipe.solr a new configuration is introduced, called `updateLog`. ``updateLog`` is enabled by default and allows atomic updates. In detail it adds a new field ``_version_`` to the schema and also adds "<updateLog />" to your solr config.
+
+Further all your indexes configured in solr.cfg needs the stored:true attribute (Except the ``default`` field).
+
+See http://wiki.apache.org/solr/Atomic_Updates for details.
+
+
+Also note, that the AtomicUpdate feature is no compatible with the "Index time boost" feature. You have to decide, whether using atomic updates, or boosting on index time. You can enable/disable atomic updates thru the collective.solr control panel. Atomic updates are enabled by default.

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -39,3 +39,4 @@ Old full description of Features
     wildcard
     suggestions
     highlighting
+    atomic_updates

--- a/solr.cfg
+++ b/solr.cfg
@@ -41,12 +41,13 @@ java_opts =
   -server
   -Xms${settings:solr-min-ram}
   -Xmx${settings:solr-max-ram}
+
 index =
-    name:allowedRolesAndUsers   type:string stored:false multivalued:true
+    name:allowedRolesAndUsers   type:string stored:true multivalued:true
     name:created                type:date stored:true
     name:Creator                type:string stored:true
     name:Date                   type:date stored:true
-    name:default                type:text indexed:true stored:false multivalued:true
+    name:default                type:text indexed:true stored:true multivalued:true
     name:Description            type:text copyfield:default stored:true
     name:effective              type:date stored:true
     name:exclude_from_nav       type:boolean indexed:false stored:true
@@ -57,16 +58,17 @@ index =
     name:is_folderish           type:boolean stored:true
     name:Language               type:string stored:true
     name:modified               type:date stored:true
-    name:object_provides        type:string stored:false multivalued:true
-    name:path_depth             type:integer indexed:true stored:false
-    name:path_parents           type:string indexed:true stored:false multivalued:true
+    name:object_provides        type:string stored:true multivalued:true
+    name:path_depth             type:integer indexed:true stored:true
+    name:path_parents           type:string indexed:true stored:true multivalued:true
     name:path_string            type:string indexed:false stored:true
     name:portal_type            type:string stored:true
     name:review_state           type:string stored:true
-    name:SearchableText         type:text copyfield:default stored:false
-    name:searchwords            type:string stored:false multivalued:true
-    name:showinsearch           type:boolean stored:false
+    name:SearchableText         type:text copyfield:default stored:true
+    name:searchwords            type:string stored:true multivalued:true
+    name:showinsearch           type:boolean stored:true
     name:Subject                type:string copyfield:default stored:true multivalued:true
     name:Title                  type:text copyfield:default stored:true
     name:Type                   type:string stored:true
     name:UID                    type:string stored:true required:true
+    name:_version_              type:long indexed:true stored:true

--- a/solr.cfg
+++ b/solr.cfg
@@ -42,12 +42,15 @@ java_opts =
   -Xms${settings:solr-min-ram}
   -Xmx${settings:solr-max-ram}
 
+additional-solrconfig =
+    <updateLog/>
+
 index =
     name:allowedRolesAndUsers   type:string stored:true multivalued:true
     name:created                type:date stored:true
     name:Creator                type:string stored:true
     name:Date                   type:date stored:true
-    name:default                type:text indexed:true stored:true multivalued:true
+    name:default                type:text indexed:true stored:false multivalued:true
     name:Description            type:text copyfield:default stored:true
     name:effective              type:date stored:true
     name:exclude_from_nav       type:boolean indexed:false stored:true

--- a/solr.cfg
+++ b/solr.cfg
@@ -32,6 +32,7 @@ unique-key = UID
 solr-version = 4
 default-operator = AND
 updateLog = true
+requestParsers-enableRemoteStreaming = true
 java_opts =
   -Dcom.sun.management.jmxremote
   -Djava.rmi.server.hostname=127.0.0.1
@@ -41,9 +42,6 @@ java_opts =
   -server
   -Xms${settings:solr-min-ram}
   -Xmx${settings:solr-max-ram}
-
-additional-solrconfig =
-    <updateLog/>
 
 index =
     name:allowedRolesAndUsers   type:string stored:true multivalued:true
@@ -74,4 +72,3 @@ index =
     name:Title                  type:text copyfield:default stored:true
     name:Type                   type:string stored:true
     name:UID                    type:string stored:true required:true
-    name:_version_              type:long indexed:true stored:true

--- a/src/collective/solr/configlet.py
+++ b/src/collective/solr/configlet.py
@@ -281,6 +281,18 @@ class SolrControlPanelAdapter(SchemaAdapterBase):
     levenshtein_distance = property(
         getLevenshteinDistance, setLevenshteinDistance)
 
+    def getAtomicUpdates(self):
+        util = queryUtility(ISolrConnectionConfig)
+        return getattr(util, 'atomic_updates', True)
+
+    def setAtomicUpdates(self, value):
+        util = queryUtility(ISolrConnectionConfig)
+        if util is not None:
+            util.atomic_updates = value
+
+    atomic_updates = property(
+        getAtomicUpdates, setAtomicUpdates)
+
 
 class SolrControlPanel(ControlPanelForm):
 

--- a/src/collective/solr/exportimport.py
+++ b/src/collective/solr/exportimport.py
@@ -48,6 +48,7 @@ class SolrConfigXMLAdapter(XMLAdapterBase):
         self.context.highlight_formatter_post = ''
         self.context.highlight_fragsize = 0
         self.context.levenshtein_distance = 0
+        self.context.atomic_updates = True
 
     def _initProperties(self, node):
         elems = node.getElementsByTagName('connection')
@@ -137,6 +138,9 @@ class SolrConfigXMLAdapter(XMLAdapterBase):
                 elif child.nodeName == 'levenshtein_distance':
                     value = float(str(child.getAttribute('value')))
                     self.context.levenshtein_distance = value
+                elif child.nodeName == 'atomic_updates':
+                    value = str(child.getAttribute('value'))
+                    self.context.atomic_updates = self._convertToBoolean(value)
 
     def _createNode(self, name, value):
         node = self._doc.createElement(name)
@@ -221,6 +225,9 @@ class SolrConfigXMLAdapter(XMLAdapterBase):
                 str(self.context.levenshtein_distance)
             )
         )
+        append(create('atomic_updates',
+               str(bool(self.context.atomic_updates))))
+
         for name in self.context.field_list:
             param = self._doc.createElement('parameter')
             param.setAttribute('name', name)

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -195,6 +195,12 @@ class SolrIndexProcessor(object):
                 attributes = set(schema.keys()).intersection(attributes)
                 if not attributes:
                     return
+
+                if uniqueKey not in attributes:
+                    # The uniqueKey is required in order to identify the
+                    # document when doing atomic updates.
+                    attributes.add(uniqueKey)
+
             data, missing = self.getData(obj, attributes=attributes)
             if not data:
                 return          # don't index with no data...

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -173,13 +173,14 @@ class SolrIndexProcessor(object):
         self.manager = manager
 
     def index(self, obj, attributes=None):
+        """Index the specified attributes for obj using atomic updates, or all
+        of them if `attributes` is `None`.
+        Also make sure the `uniqueKey` is part of attributes, and passing the
+        attributes to the self.getData() call to avoid causing Plone to index
+        all fields instead of just the necessary ones.
+        """
         conn = self.getConnection()
         if conn is not None and ICheckIndexable(obj)():
-            # unfortunately with current versions of solr we need to provide
-            # data for _all_ fields during an <add> -- partial updates aren't
-            # supported (see https://issues.apache.org/jira/browse/SOLR-139)
-            # however, the reindexing can be skipped if none of the given
-            # attributes match existing solr indexes...
             schema = self.manager.getSchema()
             if schema is None:
                 msg = 'unable to fetch schema, skipping indexing of %r'
@@ -194,7 +195,7 @@ class SolrIndexProcessor(object):
                 attributes = set(schema.keys()).intersection(attributes)
                 if not attributes:
                     return
-            data, missing = self.getData(obj)
+            data, missing = self.getData(obj, attributes=attributes)
             if not data:
                 return          # don't index with no data...
             prepareData(data)

--- a/src/collective/solr/interfaces.py
+++ b/src/collective/solr/interfaces.py
@@ -262,6 +262,19 @@ class ISolrSchema(Interface):
         required=False,
     )
 
+    atomic_updates = Bool(
+        title=_('label_atomic_update',
+                default=u'Enable atomic updates'),
+        description=_(
+            'help_atomic_updates',
+            default=u'Atomic updates allows you to update only specific '
+                    u'indexes, like "reindexObject(idxs=["portal_type"])".'
+                    u'Unfortunately atomic updates are not compatible with '
+                    u'index time boosting. If you enable atomic updates, '
+                    u'index time boosting no longer works.'),
+        default=True
+    )
+
 
 class ISolrConnectionConfig(ISolrSchema):
     """ utility to hold the connection configuration for the solr server """

--- a/src/collective/solr/interfaces.py
+++ b/src/collective/solr/interfaces.py
@@ -272,7 +272,8 @@ class ISolrSchema(Interface):
                     u'Unfortunately atomic updates are not compatible with '
                     u'index time boosting. If you enable atomic updates, '
                     u'index time boosting no longer works.'),
-        default=True
+        default=True,
+        required=False,
     )
 
 

--- a/src/collective/solr/manager.py
+++ b/src/collective/solr/manager.py
@@ -135,7 +135,7 @@ class SolrConnectionManager(object):
                 logger.debug('getting schema from solr')
                 self.setSearchTimeout()
                 try:
-                    schema = conn.getSchema()
+                    schema = conn.get_schema()
                     setLocal('schema', schema)
                 except (error, CannotSendRequest, ResponseNotReady):
                     logger.exception('exception while getting schema')

--- a/src/collective/solr/profiles/default/solr.xml
+++ b/src/collective/solr/profiles/default/solr.xml
@@ -34,5 +34,6 @@
     <highlight_fragsize
         value="100" />
     <levenshtein_distance value="0.0" />
+    <atomic_updates value="True" />
   </settings>
 </object>

--- a/src/collective/solr/tests/configlet.txt
+++ b/src/collective/solr/tests/configlet.txt
@@ -56,7 +56,8 @@ active without *having* it active.
     []
     >>> config.levenshtein_distance
     0.0
-
+    >>> config.atomic_updates
+    True
 
 Viewing the site control panel
 ------------------------------
@@ -127,6 +128,7 @@ Make some changes
     >>> browser.getControl(name='form.field_list.add').click()
     >>> browser.getControl(name='form.field_list.1.').value = 'effective'
     >>> browser.getControl(name='form.levenshtein_distance').value = '1.0'
+    >>> browser.getControl(name='form.atomic_updates').value = False
 
 Click the save button:
 
@@ -185,6 +187,8 @@ Make sure the changes have been applied correctly to the tool:
     [u'Title', u'effective']
     >>> config.levenshtein_distance
     1.0
+    >>> config.atomic_updates
+    False
 
 Now that the connection is active we can also select more filter query
 parameters from the complete list of Solr indexes, provided that we use the

--- a/src/collective/solr/tests/data/add_request.txt
+++ b/src/collective/solr/tests/data/add_request.txt
@@ -1,7 +1,7 @@
 POST /solr/update HTTP/1.1
 Host: localhost
 Accept-Encoding: identity
-Content-Length: 92
+Content-Length: 105
 Content-Type: text/xml; charset=utf-8
 
-<add><doc><field name="id">500</field><field name="name">python test doc</field></doc></add>
+<add><doc><field name="id">500</field><field name="name" update="set">python test doc</field></doc></add>

--- a/src/collective/solr/tests/data/add_request_with_boost_values.txt
+++ b/src/collective/solr/tests/data/add_request_with_boost_values.txt
@@ -1,7 +1,7 @@
 POST /solr/update HTTP/1.1
 Host: localhost
 Accept-Encoding: identity
-Content-Length: 124
+Content-Length: 125
 Content-Type: text/xml; charset=utf-8
 
-<add><doc boost="2"><field name="id" boost="0.5">500</field><field name="name" boost="5">python test doc</field></doc></add>
+<add><doc boost="2"><field name="id">500</field><field name="name" boost="5" update="set">python test doc</field></doc></add>

--- a/src/collective/solr/tests/data/add_response.txt
+++ b/src/collective/solr/tests/data/add_response.txt
@@ -1,10 +1,10 @@
 HTTP/1.1 200 OK
 Content-Type: text/xml; charset=utf-8
-Content-Length: 147
+Content-Length: 172
 Server: Jetty(6.1.3)
 
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
 <lst name="responseHeader"><int name="status">0</int><int name="QTime">4</int></lst>
+<uniqueKey>id</uniqueKey>
 </response>
-

--- a/src/collective/solr/tests/data/dummy_response.txt
+++ b/src/collective/solr/tests/data/dummy_response.txt
@@ -1,9 +1,10 @@
 HTTP/1.1 200 OK
 Content-Type: text/xml; charset=utf-8
-Content-Length: 62
+Content-Length: 89
 Server: Jetty(6.1.3)
 
 <?xml version="1.0" encoding="UTF-8"?>
 <response>
+<uniqueKey>UID</uniqueKey>
 </response>
 

--- a/src/collective/solr/tests/test_exportimport.py
+++ b/src/collective/solr/tests/test_exportimport.py
@@ -33,6 +33,7 @@ class SetupToolTests(TestCase, TarballTester):
         config.effective_steps = 900
         config.exclude_user = True
         config.levenshtein_distance = 0.2
+        config.atomic_updates = False
 
     def testImportStep(self):
         profile = 'profile-collective.solr:default'
@@ -59,6 +60,7 @@ class SetupToolTests(TestCase, TarballTester):
         self.assertEqual(config.effective_steps, 1)
         self.assertEqual(config.exclude_user, False)
         self.assertEqual(config.levenshtein_distance, 0.0)
+        self.assertTrue(config.atomic_updates)
 
     def testExportStep(self):
         tool = self.portal.portal_setup
@@ -128,6 +130,7 @@ SOLR_XML = """\
     <highlight_fragsize value="100"/>
     <field-list/>
     <levenshtein_distance value="0.2"/>
+    <atomic_updates value="False"/>
   </settings>
 </object>
 """

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -131,7 +131,8 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required = '<field name="timestamp">1972-05-11T03:45:00.000Z</field>'
+        required = ('<field name="timestamp" update="set">'
+                    '1972-05-11T03:45:00.000Z</field>')
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
     def testDateIndexingWithPythonDateTime(self):
@@ -141,7 +142,8 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required = '<field name="timestamp">1980-09-29T14:02:00.000Z</field>'
+        required = ('<field name="timestamp" update="set">'
+                    '1980-09-29T14:02:00.000Z</field>')
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
     def testDateIndexingWithPythonDate(self):
@@ -151,7 +153,8 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required = '<field name="timestamp">1982-08-05T00:00:00.000Z</field>'
+        required = ('<field name="timestamp" update="set">'
+                    '1982-08-05T00:00:00.000Z</field>')
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
     def testReindexObject(self):
@@ -201,7 +204,7 @@ class QueueIndexerTests(TestCase):
         self.proc.index(foo)
         output = str(output)
         self.assertTrue(
-            output.find('<field name="cat">nerd</field>') > 0,
+            output.find('<field name="cat" update="set">nerd</field>') > 0,
             '"cat" data not found'
         )
         self.assertEqual(output.find('price'), -1, '"price" data found?')
@@ -343,6 +346,11 @@ class ThreadedConnectionTests(TestCase):
         log = []
 
         def runner():
+
+            # fake schema response on solr connection - caches the schema
+            fakehttp(mngr.getConnection(), getData('schema.xml'))
+            mngr.getConnection().get_schema()
+
             fakehttp(mngr.getConnection(), schema)      # fake schema response
             # read and cache the schema
             mngr.getSchema()

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -109,25 +109,20 @@ class QueueIndexerTests(TestCase):
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
         self.assert_(str(output).find(
-            '<field name="price">42.0</field>') > 0, '"price" data not found')
+            '<field name="price" update="set">42.0</field>') > 0,
+            '"price" data not found')
         # then only a subset...
         response = getData('add_response.txt')
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo, attributes=['id', 'name'])
         output = str(output)
         self.assert_(
-            output.find('<field name="name">foo</field>') > 0,
+            output.find('<field name="name" update="set">foo</field>') > 0,
             '"name" data not found'
         )
         # at this point we'd normally check for a partial update:
-        #   self.assertEqual(output.find('price'), -1, '"price" data found?')
-        #   self.assertEqual(output.find('42'), -1, '"price" data found?')
-        # however, until SOLR-139 has been implemented (re)index operations
-        # always need to provide data for all attributes in the schema...
-        self.assert_(
-            output.find('<field name="price">42.0</field>') > 0,
-            '"price" data not found'
-        )
+        self.assertEqual(output.find('price'), -1, '"price" data found?')
+        self.assertEqual(output.find('42'), -1, '"price" data found?')
 
     def testDateIndexing(self):
         foo = Foo(id='zeidler', name='andi', cat='nerd',

--- a/src/collective/solr/tests/test_integration.py
+++ b/src/collective/solr/tests/test_integration.py
@@ -109,6 +109,8 @@ class IndexingTests(TestCase):
     def testIndexObject(self):
         output = []
         connection = self.proc.getConnection()
+        connection.get_schema()  # cache schema to avoid multiple calls
+
         responses = (getData('plone_schema.xml'),
                      getData('commit_response.txt'))
         output = fakehttp(connection, *responses)           # fake responses
@@ -116,7 +118,7 @@ class IndexingTests(TestCase):
         self.assertEqual(self.folder.Title(), 'Foo')
         self.assertEqual(str(output), '', 'reindexed unqueued!')
         commit()                        # indexing happens on commit
-        required = '<field name="Title">Foo</field>'
+        required = '<field name="Title" update="set">Foo</field>'
         self.assertTrue(str(output).find(required) > 0,
                         '"title" data not found')
 

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -210,6 +210,10 @@ class SolrMaintenanceTests(TestCase):
         self.assertEqual(counts['review_state'], 2)
 
     def testReindexKeepsBoostValues(self):
+        # Disable atomic updates, on order to test the index time boosting.
+        config = getUtility(ISolrConnectionConfig)
+        config.atomic_updates = False
+
         # "special" documents get boosted during indexing...
         from Products.PythonScripts.PythonScript import PythonScript
         name = 'solr_boost_index_values'

--- a/src/collective/solr/tests/test_solr.py
+++ b/src/collective/solr/tests/test_solr.py
@@ -9,7 +9,13 @@ class TestSolr(TestCase):
     def test_add(self):
         add_request = getData('add_request.txt')
         add_response = getData('add_response.txt')
+
         c = SolrConnection(host='localhost:8983', persistent=True)
+
+        # fake schema response - caches the schema
+        fakehttp(c, getData('schema.xml'))
+        c.get_schema()
+
         output = fakehttp(c, add_response)
         c.add(id='500', name='python test doc')
         res = c.flush()
@@ -30,6 +36,11 @@ class TestSolr(TestCase):
         add_request = getData('add_request_with_boost_values.txt')
         add_response = getData('add_response.txt')
         c = SolrConnection(host='localhost:8983', persistent=True)
+
+        # fake schema response - caches the schema
+        fakehttp(c, getData('schema.xml'))
+        c.get_schema()
+
         output = fakehttp(c, add_response)
         boost = {'': 2, 'id': 0.5, 'name': 5}
         c.add(boost_values=boost, id='500', name='python test doc')


### PR DESCRIPTION
This is a followup of https://github.com/collective/collective.solr/pull/80.

Issue with #80:
- I'm unable to get a proper solrconfig.xml generated by c.r.solrinstance 5.x, which supports `<updateLog/>` for the atomic update feature.

So I went ahead using collective.receipe.solrinstance 6.0.0b3.

Issue with the current build:
To boost a document or index on add no longer works. 
I don't know really why, the request sent so solr contains the `<doc boost="100"...`. But solr seems to ignore it. Any suggestions how to solve this?


**UPDATE:**

Since the AtomicUpdates and index time boosting does not work together (at least in solr 4.10.x), I implemented a new config option for the solr control panel ``atomic_updates``.  It's enabled by default. 

Further I extended the docs with some important infos about the AtomicUpdate feature. 