### PR TITLE
Add support for using different request handlers in search requests.

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 4.1.1 (unreleased)
 ------------------
 
+- Add support for using different request handlers in search requests.
+  [buchi]
+
 - solr.cfg has been moved from https://github.com/collective/collective.solr/raw/master/buildout/solr.cfg to https://github.com/collective/collective.solr/raw/master/solr.cfg.
   [timo]
 

--- a/src/collective/solr/mangler.py
+++ b/src/collective/solr/mangler.py
@@ -238,6 +238,9 @@ def subtractQueryParameters(args, request_keywords=None):
         elif key == 'b_size':
             params['rows'] = int(value)
             del args[key]
+        elif key == 'request_handler':
+            params['request_handler'] = value
+            del args[key]
 
     return params
 

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -264,11 +264,14 @@ class SolrConnection:
         del self.xmlbody[:]
 
     def search(self, **params):
+        request_handler = params.get('request_handler', 'select')
+        if 'request_handler' in params:
+            del params['request_handler']
         request = urllib.urlencode(params, doseq=True)
         logger.debug('sending request: %s' % request)
         try:
             response = self.doPost(
-                '%s/select' % self.solrBase, request,
+                '%s/%s' % (self.solrBase, request_handler), request,
                 self.formheaders
             )
         finally:

--- a/src/collective/solr/tests/test_mangler.py
+++ b/src/collective/solr/tests/test_mangler.py
@@ -314,6 +314,11 @@ class QueryParameterTests(TestCase):
         params = extract({'hl': ['foo', 'bar']})
         self.assertEqual(params, {'hl': ['foo', 'bar']})
 
+    def testAllowRequestHandlerParamter(self):
+        extract = subtractQueryParameters
+        params = extract({'request_handler': 'custom'})
+        self.assertEqual(params, {'request_handler': 'custom'})
+
     def testSortIndexCleanup(self):
         cleanup = cleanupQueryParameters
         schema = SolrSchema()

--- a/src/collective/solr/tests/test_solr.py
+++ b/src/collective/solr/tests/test_solr.py
@@ -101,6 +101,20 @@ class TestSolr(TestCase):
         self.assertEqual(normalize(output.get()), normalize(search_request))
         self.failUnless(res.find(('.//doc')))
 
+    def test_search_with_default_request_handler(self):
+        search_response = getData('search_response.txt')
+        c = SolrConnection(host='localhost:8983', persistent=True)
+        fakehttp(c, search_response)
+        c.search(q='+id:[* TO *]')
+        self.assertEqual('/solr/select', c.conn.url)
+
+    def test_search_with_custom_request_handler(self):
+        search_response = getData('search_response.txt')
+        c = SolrConnection(host='localhost:8983', persistent=True)
+        fakehttp(c, search_response)
+        c.search(request_handler='custom', q='+id:[* TO *]')
+        self.assertEqual('/solr/custom', c.conn.url)
+
     def test_delete(self):
         delete_request = getData('delete_request.txt')
         delete_response = getData('delete_response.txt')

--- a/src/collective/solr/tests/utils.py
+++ b/src/collective/solr/tests/utils.py
@@ -99,6 +99,7 @@ def fakehttp(solrconn, *fakedata):
             self.fakedata = list(fakedata)
 
         def putrequest(self, *args, **kw):
+            self.url = args[1]
             response = self.fakedata.pop(0)     # get first response
             self.sock = FakeSocket(response)    # and set up a fake socket
             output.new()                        # as well as an output buffer


### PR DESCRIPTION
With this enhancement it's possible to select another request handler than the default /select handler for search queries using the `request_handler` parameter.
This is e.g. useful for the livesearch where an optimized request handler provides much more speed than the default one.