### PR TITLE
Add zopectl.command for reindexing

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -20,6 +20,9 @@ Changelog
   does not affect server state)
   [reinhardt]
 
+- Add zopectl.command for reindexing. Do not rely on positional arguments in _get_site.
+  [tschorr]
+
 
 4.1.0 (2015-02-19)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,6 @@ setup(
       target=plone
       [zopectl.command]
       solr_clear_index=collective.solr.commands:solr_clear_index
+      solr_reindex=collective.solr.commands:solr_reindex
     ''',
 )

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'ZODB3',
         'Zope2 >= 2.13',
         'archetypes.schemaextender',
+        'argparse', # we need to support Python 2.6 (Plone 4.x)
         'collective.indexing >= 2.0a2',
         'collective.js.showmore',
         'plone.app.content',

--- a/src/collective/solr/commands.py
+++ b/src/collective/solr/commands.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import argparse
 from collective.solr.interfaces import ISolrConnectionManager
 from collective.solr.browser.maintenance import SolrMaintenanceView
 from zope.component import queryUtility
@@ -13,9 +14,15 @@ logger = logging.getLogger()
 
 
 def _get_site(app, args):
-    name = None
-    if len(args) > 2:
-        name = args[-1]
+    # Zope.Startup.zopectl.ZopeCmd.run_entrypoint promises to pass the entry point's
+    # name as the first argument and any further arguments after that, but that does not 
+    # work with plone.recipe.zope2instance. Using positional arguments therefore
+    # is unreliable - resolve to using a flag.
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--plonesite', help='Name of the Plone site', default=None)
+    namespace, unused = parser.parse_known_args(args)
+    name = namespace.plonesite
+    if name is not None:
         if name not in app:
             logger.error("Specified site '%s' not found in database." % name)
             sys.exit(1)
@@ -43,8 +50,8 @@ def _solr_connection():
 
 def solr_clear_index(app, args):
     """Removes all data from a Solr index. Equivalent to removing the
-    `data/index` directory while Solr is stopped. You can optionally specify
-    the id of the Plone site as the first command line argument.
+    `data/index` directory while Solr is stopped.
+    You can optionally specify the id of the Plone site with --plonesite <siteid>.
     """
     _get_site(app, args)  # calls setSite so queryUtility works
     conn = _solr_connection()
@@ -55,7 +62,8 @@ def solr_clear_index(app, args):
 def solr_reindex(app, args):
     """Reindex Solr. This is equivalent to /@@solr-maintenance/reindex, but
     can handle more documents. Using reindex from the browser will stop
-    eventually if there are too many documents, leaving the index incomplete
+    eventually if there are too many documents, leaving the index incomplete.
+    You can optionally specify the id of the Plone site with --plonesite <siteid>.
     """
     site = makerequest(_get_site(app, args))
     mv = SolrMaintenanceView(site, site.REQUEST)


### PR DESCRIPTION
This adds a zopectl.command entry point for reindexing Solr. I needed this because when calling @@solr-maintenance/reindex in the browser, reindexing stopped after ~ 7500 documents, with still ~90000 documents to go. I guess it is the browser that eventually closes the connection.
The PR also fixes a problem in _get_site with recent Zope versions (args has changed).