### PR TITLE
Link to github

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author_email='info@jarn.com',
     maintainer='Plone Community',
     maintainer_email='plone-developers@lists.sourceforge.net',
-    url='http://plone.org/products/collective.solr',
+    url='https://github.com/collective/collective.solr',
     license='GPL version 2',
     packages=find_packages('src'),
     package_dir={'': 'src'},


### PR DESCRIPTION
Not only because plone.org/products will die soon, but also because it's so useful to have this URL show up on pypi.