### PR TITLE
Remove waitFlush

### DIFF
--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -274,7 +274,7 @@ class SolrIndexProcessor(object):
                     # and we might wait a bit longer on delete's this way
                     conn.flush()
                 else:
-                    conn.commit(waitFlush=wait, waitSearcher=wait)
+                    conn.commit(waitSearcher=wait)
             except (SolrException, error):
                 logger.exception('exception during commit')
             self.manager.closeConnection()

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -240,14 +240,12 @@ class SolrConnection:
         xstr = ''.join(lst)
         return self.doUpdateXML(xstr)
 
-    def commit(self, waitFlush=True, waitSearcher=True, optimize=False):
+    def commit(self, waitSearcher=True, optimize=False):
         data = {
             'committype': optimize and 'optimize' or 'commit',
             'nowait': not waitSearcher and ' waitSearcher="false"' or '',
-            'noflush': not waitFlush and not waitSearcher and
-            ' waitFlush="false"' or ''
         }
-        xstr = '<%(committype)s%(noflush)s%(nowait)s/>' % data
+        xstr = '<%(committype)s%(nowait)s/>' % data
         self.doUpdateXML(xstr)
         return self.flush()
 

--- a/src/collective/solr/tests/data/commit_request_no_wait.txt
+++ b/src/collective/solr/tests/data/commit_request_no_wait.txt
@@ -1,7 +1,0 @@
-POST /solr/update HTTP/1.1
-Host: localhost
-Accept-Encoding: identity
-Content-Length: 48
-Content-Type: text/xml; charset=utf-8
-
-<commit waitFlush="false" waitSearcher="false"/>

--- a/src/collective/solr/tests/test_solr.py
+++ b/src/collective/solr/tests/test_solr.py
@@ -70,7 +70,7 @@ class TestSolr(TestCase):
         commit_response = getData('commit_response.txt')
         c = SolrConnection(host='localhost:8983', persistent=True)
         output = fakehttp(c, commit_response)
-        c.commit(waitFlush=False)
+        c.commit()
         self.failUnlessEqual(str(output), commit_request)
 
     def test_commit_no_wait_searcher(self):
@@ -79,14 +79,6 @@ class TestSolr(TestCase):
         c = SolrConnection(host='localhost:8983', persistent=True)
         output = fakehttp(c, commit_response)
         c.commit(waitSearcher=False)
-        self.failUnlessEqual(str(output), commit_request)
-
-    def test_commit_no_wait(self):
-        commit_request = getData('commit_request_no_wait.txt')
-        commit_response = getData('commit_response.txt')
-        c = SolrConnection(host='localhost:8983', persistent=True)
-        output = fakehttp(c, commit_response)
-        c.commit(waitFlush=False, waitSearcher=False)
         self.failUnlessEqual(str(output), commit_request)
 
     def test_search(self):


### PR DESCRIPTION
It's been long deprecated (since Solr 1.4 - November 2009),
it has been finally removed on Solr 4.0 - October 2014).

Source http://wiki.apache.org/solr/UpdateXmlMessages#Optional_attributes_for_.22commit.22_and_.22optimize.22

Release dates: https://en.wikipedia.org/wiki/Apache_Solr

While working with Solr locally I stumbled over this traceback: https://github.com/silverstripe-labs/silverstripe-fulltextsearch/issues/34 and seems that that parameter is long gone.

Was there any previous discussion about the removal of it? Nobody stumbled upon it?