### PR TITLE
Move inline function to global scope

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -26,6 +26,8 @@ Changelog
 - Add zopectl.command for reindexing. Do not rely on positional arguments in _get_site.
   [tschorr]
 
+- Move inline function out of to the global scope to make it more readable.
+  [gforcada]
 
 4.1.0 (2015-02-19)
 ------------------

--- a/src/collective/solr/queryparser.py
+++ b/src/collective/solr/queryparser.py
@@ -269,3 +269,12 @@ def quote(term, textfield=False):
                 stack.current.append('\\%s' % special)
         i += 1
     return str(stack)
+
+
+def quote_iterable_item(term):
+    if isinstance(term, unicode):
+        term = term.encode('utf-8')
+    quoted = quote(term)
+    if not quoted.startswith('"') and not quoted == term:
+        quoted = quote('"' + term + '"')
+    return quoted

--- a/src/collective/solr/search.py
+++ b/src/collective/solr/search.py
@@ -10,6 +10,7 @@ from collective.solr.mangler import optimizeQueryParameters
 from collective.solr.mangler import subtractQueryParameters
 from collective.solr.parser import SolrResponse
 from collective.solr.queryparser import quote
+from collective.solr.queryparser import quote_iterable_item
 from collective.solr.utils import isWildCard
 from collective.solr.utils import prepareData
 from collective.solr.utils import prepare_wildcard
@@ -160,14 +161,7 @@ class Search(object):
             elif isinstance(value, (tuple, list)):
                 # list items should be treated as literals, but
                 # nevertheless only get quoted when necessary
-                def quoteitem(term):
-                    if isinstance(term, unicode):
-                        term = term.encode('utf-8')
-                    quoted = quote(term)
-                    if not quoted.startswith('"') and not quoted == term:
-                        quoted = quote('"' + term + '"')
-                    return quoted
-                value = '(%s)' % ' OR '.join(map(quoteitem, value))
+                value = '(%s)' % ' OR '.join(map(quote_iterable_item, value))
             elif isinstance(value, set):        # sets are taken literally
                 if len(value) == 1:
                     query[name] = ''.join(value)


### PR DESCRIPTION
There's no benefit of having the function defined inline,
it just clutters the, already long, buildQueryAndParameters method.