### PR TITLE
Soft commit on reindexes

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -37,6 +37,10 @@ Changelog
 - Unify all exceptions raised by collective.solr.
   [gforcada]
 
+- Soft commit changes while reindexing.
+  This allows to get results on searches while reindexing is taking place.
+  [gforcada]
+
 4.1.0 (2015-02-19)
 ------------------
 

--- a/src/collective/solr/browser/maintenance.py
+++ b/src/collective/solr/browser/maintenance.py
@@ -121,7 +121,7 @@ class SolrMaintenanceView(BrowserView):
         schema = manager.getSchema()
         key = schema.uniqueKey
         updates = {}            # list to hold data to be updated
-        flush = lambda: conn.flush()
+        flush = lambda: conn.commit(soft=True)
         flush = notimeout(flush)
 
         def checkPoint():

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -270,12 +270,13 @@ class SolrConnection:
 
         return self.doUpdateXML(xstr)
 
-    def commit(self, waitSearcher=True, optimize=False):
+    def commit(self, waitSearcher=True, optimize=False, soft=False):
         data = {
             'committype': optimize and 'optimize' or 'commit',
             'nowait': not waitSearcher and ' waitSearcher="false"' or '',
+            'soft': soft and ' softCommit="true"' or '',
         }
-        xstr = '<%(committype)s%(nowait)s/>' % data
+        xstr = '<%(committype)s%(soft)s%(nowait)s/>' % data
         self.doUpdateXML(xstr)
         return self.flush()
 


### PR DESCRIPTION
Allow data to be saved and ready to be used by Solr.

Note that at the end of reindex a hard commit is done which will save
the changes on the disk.

See:
http://wiki.apache.org/solr/UpdateXmlMessages#A.22commit.22_and_.22optimize.22

The idea is that if you are running a reindex to have something on Solr *while* the reindex is already going on, this way a reindex that takes several hours (+7 or 8) does not need to be be in maintenance mode (as no results will  be displayed on the search view as soon as you enable c.solr).

I still need to create a test and a changelog entry. But comments welcome.