### PR TITLE
Revert back to zopectl.command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
     entry_points='''
       [z3c.autoinclude.plugin]
       target=plone
-      [plone.recipe.zope2instance.ctl]
+      [zopectl.command]
       solr_clear_index=collective.solr.commands:solr_clear_index
       solr_reindex=collective.solr.commands:solr_reindex
     ''',


### PR DESCRIPTION
``plone.recipe.zope2instance.ctl`` and ``zopectl.command`` provide totally different arguments to the entry point methods.

I thought I had tried it, but p.r.z2instance provides something completely different than zopectl.command :-/
