### PR TITLE
Fix field-list export

### DIFF
--- a/src/collective/solr/exportimport.py
+++ b/src/collective/solr/exportimport.py
@@ -219,6 +219,10 @@ class SolrConfigXMLAdapter(XMLAdapterBase):
         )
         field_list = self._doc.createElement('field-list')
         append(field_list)
+        for name in self.context.field_list:
+            param = self._doc.createElement('parameter')
+            param.setAttribute('name', name)
+            field_list.appendChild(param)
         append(
             create(
                 'levenshtein_distance',
@@ -228,10 +232,6 @@ class SolrConfigXMLAdapter(XMLAdapterBase):
         append(create('atomic_updates',
                str(bool(self.context.atomic_updates))))
 
-        for name in self.context.field_list:
-            param = self._doc.createElement('parameter')
-            param.setAttribute('name', name)
-            facets.appendChild(param)
         return node
 
 

--- a/src/collective/solr/tests/test_exportimport.py
+++ b/src/collective/solr/tests/test_exportimport.py
@@ -33,6 +33,7 @@ class SetupToolTests(TestCase, TarballTester):
         config.effective_steps = 900
         config.exclude_user = True
         config.levenshtein_distance = 0.2
+        config.field_list = ('review_state', 'Title', )
         config.atomic_updates = False
 
     def testImportStep(self):
@@ -128,7 +129,10 @@ SOLR_XML = """\
     <highlight_formatter_pre value="["/>
     <highlight_formatter_post value="]"/>
     <highlight_fragsize value="100"/>
-    <field-list/>
+    <field-list>
+      <parameter name="review_state" />
+      <parameter name="Title" />
+    </field-list>
     <levenshtein_distance value="0.2"/>
     <atomic_updates value="False"/>
   </settings>


### PR DESCRIPTION
It was appending them to facets setting.

It was broken since 2012 (https://github.com/collective/collective.solr/commit/4228c98ea8ea51d3efad1e81818a97efb0329f4e) but nobody noticed :-)