### PR TITLE
Allow range minmax

### DIFF
--- a/src/collective/solr/mangler.py
+++ b/src/collective/solr/mangler.py
@@ -14,6 +14,7 @@ ranges = {
     'min': '[%s TO *]',
     'max': '[* TO %s]',
     'min:max': '[%s TO %s]',
+    'minmax': '[%s TO %s]',
 }
 
 sort_aliases = {


### PR DESCRIPTION
ZCatalog accepts ranges defined as ``min:max`` as well as ``minmax``.