### PR TITLE
Remove obsolete Extensions uninstall script

### DIFF
--- a/src/collective/solr/Extensions/install.py
+++ b/src/collective/solr/Extensions/install.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-
-def uninstall(portal, reinstall=False):
-    if not reinstall:
-        setup_tool = portal.portal_setup
-        profile = 'profile-collective.solr:uninstall'
-        setup_tool.runAllImportStepsFromProfile(profile)


### PR DESCRIPTION
Uninstall profile is found automatically since Plone 4.3.7
http://docs.plone.org/develop/addons/components/genericsetup.html#uninstall-profile