### PR TITLE
Ignore exceptions when reindexing Solr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- New flag: Ignore exceptions that occur during reindexing. 
+  Ignoring exceptions becomes the default when running solr_reindex.
+  [tschorr]
 
 
 5.0.3 (2016-06-05)

--- a/src/collective/solr/browser/maintenance.py
+++ b/src/collective/solr/browser/maintenance.py
@@ -95,7 +95,7 @@ class SolrMaintenanceView(BrowserView):
         return 'solr index cleared.'
 
     def reindex(self, batch=1000, skip=0, limit=0, ignore_portal_types=None,
-                only_portal_types=None, idxs=[]):
+                only_portal_types=None, idxs=[], ignore_exceptions=False):
         """ find all contentish objects (meaning all objects derived from one
             of the catalog mixin classes) and (re)indexes them """
 
@@ -127,7 +127,12 @@ class SolrMaintenanceView(BrowserView):
         def checkPoint():
             for my_boost_values, data in updates.values():
                 adder = data.pop('_solr_adder')
-                adder(conn, boost_values=my_boost_values, **data)
+                try:
+                    adder(conn, boost_values=my_boost_values, **data)
+                except Exception, e:
+                    logger.warn('Error %s @ %s', e, data['path_string'])
+                    if not ignore_exceptions:
+                        raise
             updates.clear()
             msg = 'intermediate commit (%d items processed, ' \
                   'last batch in %s)...\n' % (processed, lap.next())

--- a/src/collective/solr/commands.py
+++ b/src/collective/solr/commands.py
@@ -74,4 +74,4 @@ def solr_reindex(app, args):
     """
     site = makerequest(_get_site(app, args))
     mv = SolrMaintenanceView(site, site.REQUEST)
-    mv.reindex()
+    mv.reindex(ignore_exceptions=True)

--- a/src/collective/solr/commands.py
+++ b/src/collective/solr/commands.py
@@ -84,4 +84,3 @@ def solr_reindex(app, args):
     ignore_exceptions = namespace.ignore_exceptions == 'yes'
     mv = SolrMaintenanceView(site, site.REQUEST)
     mv.reindex(ignore_exceptions=ignore_exceptions)
-

--- a/src/collective/solr/commands.py
+++ b/src/collective/solr/commands.py
@@ -73,5 +73,15 @@ def solr_reindex(app, args):
     --plonesite <siteid>.
     """
     site = makerequest(_get_site(app, args))
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--ignore_exceptions',
+        help='Ignore exceptions during reindexing (yes/no)',
+        choices=['yes', 'no'],
+        default='yes'
+    )
+    namespace, unused = parser.parse_known_args(args)
+    ignore_exceptions = namespace.ignore_exceptions == 'yes'
     mv = SolrMaintenanceView(site, site.REQUEST)
-    mv.reindex(ignore_exceptions=True)
+    mv.reindex(ignore_exceptions=ignore_exceptions)
+

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from random import randint
 from DateTime import DateTime
 from Missing import MV
 from Products.CMFCore.utils import getToolByName
@@ -63,16 +62,14 @@ DEFAULT_OBJS = [
 
 
 class RaisingAdder(DefaultAdder):
-    """AddHandler that raises exceptions
+    """AddHandler that raises an exception when called
     """
 
     implements(ISolrAddHandler)
     adapts(IBaseObject)
 
     def __call__(self, conn, **data):
-        exceptions = [ValueError, TypeError, IndexError]
-        choice = exceptions[randint(0, len(exceptions))]
-        raise choice
+        raise Exception('Test')
 
 
 class SolrMaintenanceTests(TestCase):

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -261,15 +261,14 @@ class SolrMaintenanceTests(TestCase):
 
     def testReindexIgnoreExceptions(self):
         provideAdapter(RaisingAdder, name='Image')
-        search = lambda: [result['getId'] for result in
-                          getUtility(ISearch)
-                          ('Title:foo^2 OR Description:foo').results()]
         # ignore_exceptions=False should raise the handler's exception, 
         # thereby aborting the reindex tx
         self.folder.invokeFactory('Image', id='dull', title='foo',
                                   description='the bar is missing here')
         maintenance = self.portal.unrestrictedTraverse('solr-maintenance')
-        self.assertRaises(Exception, maintenance.reindex, ignore_exceptions=False)
+        self.assertRaises(Exception, 
+                          maintenance.reindex, 
+                          ignore_exceptions=False)
         # ignore_exceptions=True should commit the reindex tx.
         # The object causing the exception will not be indexed
         maintenance = self.portal.unrestrictedTraverse('solr-maintenance')


### PR DESCRIPTION
Reindexing the entire Solr index currently aborts if an exception is encountered.

Propagating exceptions imho is fine when indexing a single object, but when (re)indexing the whole database it should be possible to ignore exceptions. `portal_catalog` 'Clear and Rebuild' also ignores exceptions and I think c.solr should behave in the same way if just for consistency.

This PR adds a new flag 'ignore_exceptions' to browser.maintenance.reindex(). The behaviour of `@@solr-maintenance/reindex` remains unchanged, but ignoring exceptions becomes the default when using `bin/instance solr_reindex`. 