### PR TITLE
Workaround for problem with type name with whitespace

### DIFF
--- a/src/collective/solr/search.py
+++ b/src/collective/solr/search.py
@@ -178,6 +178,9 @@ class Search(object):
                         if value[0] != '"':
                             value = '"%s"' % value
                 else:
+                    if name == 'portal_type':
+                        value = '"' + value + '"'
+
                     value = quote(value)
                 if not value:   # don't search for empty strings, even quoted
                     continue

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -1122,7 +1122,7 @@ class SolrServerTests(TestCase):
         self.assertEqual([(r.Title, r.path_string) for r in results],
                          [('News', '/plone/news/aggregator')])
         self.assertEqual(len(log), 1)
-        self.assertEqual(log[-1][1]['fq'], ['+portal_type:Collection'], log)
+        self.assertEqual(log[-1][1]['fq'], ['+portal_type:"Collection"'], log)
         # let's test again with an already existing filter query parameter
         request = dict(SearchableText='News', fq='+review_state:published')
         results = solrSearchResults(request, portal_type='Collection')


### PR DESCRIPTION
It's connected with this bug https://github.com/collective/collective.solr/issues/137.
Portal types in portal_type from fq, always should be surrounded by quotes.
