### PR TITLE
Implement reindexing the path indexes in solr [5.x].

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement reindexing the path indexes in solr. This means in solr path_string, path_parents and path_depth are updated on `obj.reindexObject(idxs=['path'])`.
+  [mathias.leimgruber]
 
 
 5.0.3 (2016-06-05)

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -181,7 +181,14 @@ class SolrIndexProcessor(object):
                 msg = 'schema is missing unique key, skipping indexing of %r'
                 logger.warning(msg, obj)
                 return
+
             if attributes is not None:
+
+                if 'path' in attributes:
+                    attributes = list(attributes)
+                    attributes.extend(['path_string', 'path_parents',
+                                       'path_depth'])
+
                 attributes = set(schema.keys()).intersection(attributes)
                 if not attributes:
                     return

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from Acquisition import aq_base
+from Acquisition import aq_parent
 from DateTime import DateTime
 from Missing import MV
 from Products.CMFCore.utils import getToolByName
@@ -478,6 +480,41 @@ class SolrServerTests(TestCase):
         commit()
         self.assertEqual(log, [])
         self.assertEqual(self.search('+Title:Foo').results().numFound, '1')
+
+    def testReindexPathIndex(self):
+        manager = getUtility(ISolrConnectionManager)
+        connection = manager.getConnection()
+        proc = SolrIndexProcessor(manager)
+        proc.reindex(self.folder)
+        proc.commit()
+        search = lambda query: numFound(connection.search(q=query).read())
+
+        self.assertEqual(search('+path_parents:\/plone\/news\/folder'), 1)
+
+        # Rename obj, without triggering any events.
+        parent = aq_parent(self.folder)
+        parent._delObject('folder', suppress_events=True)
+        ob = aq_base(self.folder)
+        ob._setId('new_id')
+        commit()
+
+        # No change in solr so far
+        self.assertEqual(search('+path_parents:\/plone\/news\/folder'), 1)
+
+        proc.reindex(self.folder, attributes=['path', ])
+        proc.commit()
+
+        # Crosscheck
+        self.assertEqual(search('+path_parents:\/plone\/news\/folder'), 0)
+
+        self.assertEqual(search('+path_parents:\/plone\/news\/new_id'), 1)
+
+        # Check path_string is also up to date
+        response = SolrResponse(
+            connection.search(q='+path_parents:\/plone\/news\/new_id'))
+
+        self.assertEquals('/plone/news/new_id',
+                          response.results()[0]['path_string'])
 
     def testDateBefore1000AD(self):
         # AT's default "floor date" of `DateTime(1000, 1)` is converted


### PR DESCRIPTION
With the plone catalog the following works as expected:

```
obj.reindexObject(idxs=['path'])
``` 

But the solr integration filtered the `path` attribute before reindexing, since there's no equivalent solr index. 

This change extends the indexed attributes with the path relevant solr indexes `path_string`, `path_parents` and `path_depth`