### PR TITLE
Added upgrade step for registry when upgrading from 5.0.3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,17 @@ Changelog
 6.0a2 (unreleased)
 ------------------
 
+- Added upgrade step for registry to upgrade from version 5.0.3.
+  Otherwise you get KeyError: ``collective.solr.facets`` in the search viewlet.
+  And on the control panel you get another KeyError: 'Interface
+  ``collective.solr.interfaces.ISolrSchema`` defines a field
+  ``index_timeout``, for which there is no record.'
+  Note that this resets your configuration.
+  You may want to make a screen shot of your previous configuration
+  before you update your buildout to collective.solr 6.
+  See https://github.com/collective/collective.solr/issues/155
+  [maurits]
+
 - Implement reindexing the path indexes in solr. This means in solr path_string, path_parents and path_depth are updated on `obj.reindexObject(idxs=['path'])`.
   [mathias.leimgruber]
 

--- a/src/collective/solr/profiles/default/metadata.xml
+++ b/src/collective/solr/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2</version>
+  <version>3</version>
   <dependencies>
     <dependency>profile-plone.app.registry:default</dependency>
     <dependency>profile-plone.restapi:default</dependency>

--- a/src/collective/solr/setuphandlers.py
+++ b/src/collective/solr/setuphandlers.py
@@ -1,8 +1,16 @@
 # -*- coding: utf-8 -*-
+from collective.solr.interfaces import ISolrConnectionConfig
+from collective.solr.interfaces import ISolrSchema
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
-import logging
-logger = logging.getLogger('collective.solr')
+from zope.component import getSiteManager
+from zope.component import getUtility
+from zope.component import queryUtility
 
+import logging
+
+
+logger = logging.getLogger('collective.solr')
 PROFILE_ID = 'profile-collective.solr:default'
 
 
@@ -10,3 +18,16 @@ def migrateTo2(context):
     setup_tool = getToolByName(context, 'portal_setup')
     setup_tool.runImportStepFromProfile(PROFILE_ID, 'browserlayer')
     logger.info('Migrated to version 2: add browserlayer')
+
+
+def update_registry(context):
+    registry = getUtility(IRegistry)
+    util = queryUtility(ISolrConnectionConfig)
+    if util is not None:
+        # Preferably we would get the previous data from this utility, so we
+        # can restore the settings.  But the utility is broken.  The best we
+        # can do, is remove it.
+        sm = getSiteManager()
+        sm.unregisterUtility(provided=ISolrConnectionConfig)
+
+    registry.registerInterface(ISolrSchema, prefix='collective.solr')

--- a/src/collective/solr/upgrades.zcml
+++ b/src/collective/solr/upgrades.zcml
@@ -13,5 +13,14 @@
     profile="collective.solr:default"
     />
 
+  <genericsetup:upgradeStep
+    title="Upgrade to collective.solr 3"
+    description="Add our interface to the registry and remove old config util."
+    source="2"
+    destination="3"
+    handler=".setuphandlers.update_registry"
+    sortkey="1"
+    profile="collective.solr:default"
+    />
 
 </configure>


### PR DESCRIPTION
Otherwise you get KeyError: `collective.solr.facets` in the search viewlet.

And on the control panel you get another KeyError: 'Interface `collective.solr.interfaces.ISolrSchema` defines a field `index_timeout`, for which there is no record.'

We remove the old config utility in this step, because the object is broken.

See https://github.com/collective/collective.solr/issues/155