### PR TITLE
solr.cfg: configure JMX host and port separately.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 6.0a2 (unreleased)
 ------------------
 
+- solr.cfg: configure JMX host and port separately.  [maurits]
+
 - Added link to Solr sync in our control panel.  Added titles to all
   four maintenance links that briefly explain what they do.  [maurits]
 

--- a/solr.cfg
+++ b/solr.cfg
@@ -7,6 +7,8 @@ parts +=
 [settings]
 solr-host = 127.0.0.1
 solr-port = 8983
+jmx-host = 127.0.0.1
+jmx-port = 8984
 solr-min-ram = 128M
 solr-max-ram = 256M
 
@@ -35,8 +37,8 @@ updateLog = true
 requestParsers-enableRemoteStreaming = true
 java_opts =
   -Dcom.sun.management.jmxremote
-  -Djava.rmi.server.hostname=127.0.0.1
-  -Dcom.sun.management.jmxremote.port=8984
+  -Djava.rmi.server.hostname=${settings:jmx-host}
+  -Dcom.sun.management.jmxremote.port=${settings:jmx-port}
   -Dcom.sun.management.jmxremote.ssl=false
   -Dcom.sun.management.jmxremote.authenticate=false
   -server


### PR DESCRIPTION
The config was hardcoding the JMX (Java Management Extensions) host and port. Now it is clearer that you can configure them.

Mostly, I found it strange that there was a `solr-port` setting and we were completely ignoring that in the `java_opts` and instead used hardcoded port 8984. To me this gave the impression that this port 8984 was only used at build time to maybe set a default, and that `solr-instance fg` would just use the port from the settings and port 8984 would never be used.

Initially I changed that to use the same settings, with `${:host}` and `${:port}`.
That seems to work fine, and we could also use that to keep things simple.
But probably it is better to keep the ports separate.

I did not know JMX, but you can start `jconsole` and connect to your Solr instance and see some statistics. See https://cwiki.apache.org/confluence/display/solr/Using+JMX+with+Solr