### PR TITLE
Fix: Indexing with atomic-update can remove all other attributes from the index.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Changelog
 5.0.4 (unreleased)
 ------------------
 
+- Fix: Reindexing solr-objects with specific attributes (atomic-update) will remove
+  all indexed attributes on an object if it does not provide this index or if the
+  field is multivalued and the value is empty. (fixes #171)
+  [elioschmutz]
+
 - Use unittest instead unittest2 in test_browser_suggest.py to fix tests.
   [elioschmutz]
 

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -199,7 +199,7 @@ class SolrIndexProcessor(object):
                     attributes.add(uniqueKey)
 
             data, missing = self.getData(obj, attributes=attributes)
-            if not data:
+            if not data or not set(data.keys()) - set([uniqueKey]):
                 return          # don't index with no data...
             prepareData(data)
             if data.get(uniqueKey, None) is not None and not missing:

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -257,8 +257,14 @@ class SolrConnection:
                 tmpl = tmpl.replace(' update="set"', '')
 
             if isinstance(v, (list, tuple)):  # multi-valued
-                for value in v:
-                    lst.append(tmpl % self.escapeVal(value))
+                if v:
+                    for value in v:
+                        lst.append(tmpl % self.escapeVal(value))
+                else:
+                    # Add an empty element for empty lists/tuples.
+                    # Otherwise all indexes gets removed if you update an empty
+                    # multivalued attribute.
+                    lst.append(tmpl % '')
             else:
                 lst.append(tmpl % self.escapeVal(v))
         lst.append('</doc>')

--- a/src/collective/solr/tests/data/schema.xml
+++ b/src/collective/solr/tests/data/schema.xml
@@ -1,6 +1,6 @@
 HTTP/1.1 200 OK
 Content-Type: text/xml; charset=utf-8
-Content-Length: 7086
+Content-Length: 7071
 Server: Jetty(6.1.3)
 
 <?xml version="1.0" encoding="UTF-8"?>
@@ -66,7 +66,7 @@ Server: Jetty(6.1.3)
  <fields>
    <field name="id" type="string" indexed="true" stored="true" required="true"/> 
    <field name="sku" type="textTight" indexed="true" stored="true" omitNorms="true"/>
-   <field name="name" type="text" indexed="true" stored="true" required="true" />
+   <field name="name" type="text" indexed="true" stored="true" />
    <field name="nameSort" type="string" indexed="true" stored="false"/>
    <field name="alphaNameSort" type="alphaOnlySort" indexed="true" stored="false"/>
    <field name="manu" type="text" indexed="true" stored="true" omitNorms="true"/>

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -186,8 +186,35 @@ class QueueIndexerTests(TestCase):
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         # indexing sends data
+        self.proc.index(Foo(text='lorem ipsum'))  # required id is missing
+        self.assertEqual(str(output), '')
+
+    def testNoIndexingWithOnlyUniqueKeyField(self):
+        response = getData('dummy_response.txt')
+        # fake add response
+        output = fakehttp(self.mngr.getConnection(), response)
+        # indexing sends data
         self.proc.index(Foo(id='500'))
         self.assertEqual(str(output), '')
+
+    def testNoIndexingWithOnlyUniqueKeyFieldAndNotExistingIndex(self):
+        response = getData('dummy_response.txt')
+        # fake add response
+        output = fakehttp(self.mngr.getConnection(), response)
+        # indexing sends data
+        self.proc.index(Foo(id='500', notexisting='some data'))
+        self.assertEqual(str(output), '')
+
+    def testIndexingEmptyMultiValuedFieldWillAddFieldAsWell(self):
+        response = getData('dummy_response.txt')
+        # fake add response
+        output = fakehttp(self.mngr.getConnection(), response)
+        # indexing sends data
+        self.proc.index(Foo(id='500', features=()))
+        self.assertIn(
+            '<field name="features" update="set"></field>',
+            str(output),
+            "The empty multivalued field have to be in the output neverless")
 
     def testIndexerMethods(self):
         class Bar(Foo):

--- a/src/collective/solr/tests/test_parser.py
+++ b/src/collective/solr/tests/test_parser.py
@@ -129,7 +129,7 @@ class ParserTests(TestCase):
         self.assertEqual(schema['defaultSearchField'], 'text')
         self.assertEqual(schema['uniqueKey'], 'id')
         self.assertEqual(schema['solrQueryParser'].defaultOperator, 'OR')
-        self.assertEqual(schema['requiredFields'], ['id', 'name'])
+        self.assertEqual(schema['requiredFields'], ['id'])
         self.assertEqual(schema['id'].type, 'string')
         self.assertEqual(schema['id'].class_, 'solr.StrField')
         self.assertEqual(schema['id'].required, True)
@@ -151,7 +151,7 @@ class ParserTests(TestCase):
         self.assertEqual(schema.word.indexed, False)
         fields = schema.values()
         self.assertEqual(len([f for f in fields if
-                              getattr(f, 'required', False)]), 2)
+                              getattr(f, 'required', False)]), 1)
         self.assertEqual(len([f for f in fields if
                               getattr(f, 'multiValued', False)]), 3)
 

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -2,7 +2,6 @@
 from Acquisition import aq_base
 from Acquisition import aq_parent
 from DateTime import DateTime
-from Missing import MV
 from Products.CMFCore.utils import getToolByName
 from collective.indexing.queue import getQueue
 from collective.indexing.queue import processQueue
@@ -1215,7 +1214,7 @@ class SolrServerTests(TestCase):
         self.maintenance.reindex()
         results = solrSearchResults(SearchableText='Welcome')
         self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].get('Subject'), MV)
+        self.assertEqual(results[0].get('Subject'), [''])
         schema = self.search.getManager().getSchema()
         expected = set(list(schema.stored) + ['score'])     # score gets added
         self.assertEqual(set(results[0].keys()), expected)


### PR DESCRIPTION
This PR fixes the issue where indexes can be removed with an atomic-update.

Sending the following xml to the solr will update the Description-index of the object with UID xxx with the string "Example"
```
<add><doc><field name="UID">xxx</field><field name="Description" update="set">Example</field></doc></add>
```

Sending the following xml to the solr will update the searchwords-index of the object with UID yyy with a list with an empty string: [""]
```
<add><doc><field name="UID">yyy</field><field name="searchwords" update="set"></field></doc></add>
```

Sending the following xml to the solr will remove all indexes of the object with the UID zzz
```
<add><doc><field name="UID">zzz</field></doc></add>
```

So the last request would be bad. We have two different cases where this request will be performed:

**Case 1:**
If you do an atomic update for an object which does not provide an index-method for the given attribute.

Why?

1. for atomic updates, we need the unique key: https://github.com/collective/collective.solr/blob/5.x/src/collective/solr/indexer.py#L199
2. the getData-method (https://github.com/collective/collective.solr/blob/5.x/src/collective/solr/indexer.py#L201) removes the attribute if it does not exist on the object
3. the data (https://github.com/collective/collective.solr/blob/5.x/src/collective/solr/indexer.py#L202) will not be empty because we still have the unique key inside.

This ends up in the following xml-string:
```
<add><doc><field name="UID">zzz</field></doc></add>
```

**Case 2:**
If you do an atomic update with a multivalued attribute which is empty on an object.

Why?

1. the add-method of the solr.py (https://github.com/collective/collective.solr/blob/5.x/src/collective/solr/solr.py#L212) will add the unique key field to the xml (https://github.com/collective/collective.solr/blob/5.x/src/collective/solr/solr.py#L243)
2. the empty multivalued field will be skipped (https://github.com/collective/collective.solr/blob/5.x/src/collective/solr/solr.py#L260)

This ends up in the following xml-string, too:
```
<add><doc><field name="UID">zzz</field></doc></add>
```

Solution:
======
1. If we have data, check if there are other fields than the UID (https://github.com/collective/collective.solr/compare/5.x...es-171-fix-atomic-update?expand=1#diff-6c045cfe6307fd329498dfe3e0f948daR202). If not, we skip it.

2. If we have an empty multivalued field, we add a placeholder with an empty value for the field (https://github.com/collective/collective.solr/compare/5.x...es-171-fix-atomic-update?expand=1#diff-ce14634d17ed2770c78538cdc89f0fcdR263).
This will perform a request with the following xml-string:
```
<add><doc><field name="UID">yyy</field><field name="searchwords" update="set"></field></doc></add>
```

closes #171 