### PR TITLE
Use unittest instead unittest2 in test_browser_suggest.py to fix tests.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 5.0.4 (unreleased)
 ------------------
 
+- Use unittest instead unittest2 in test_browser_suggest.py to fix tests.
+  [elioschmutz]
+
 - Implement reindexing the path indexes in solr. This means in solr path_string, path_parents and path_depth are updated on `obj.reindexObject(idxs=['path'])`.
   [mathias.leimgruber]
 

--- a/src/collective/solr/tests/test_browser_suggest.py
+++ b/src/collective/solr/tests/test_browser_suggest.py
@@ -9,7 +9,7 @@ from plone.app.testing import TEST_USER_ID
 from zope.component import getMultiAdapter
 
 import json
-import unittest2 as unittest
+import unittest
 
 
 class MockResponse():


### PR DESCRIPTION
Tests for the 5.x branch are currently failing.

This PR fixes the tests for the 5.x branch.