### PR TITLE
Fix master

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 6.0a3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix tests to work with latest collective.indexing.
+  [gforcada]
 
 6.0a2 (2017-07-17)
 ------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 appdirs==1.4.2
 packaging==16.8
 pyparsing==2.1.10
-setuptools==34.3.0
+setuptools==38.7.0
 six==1.10.0
-zc.buildout==2.8.0
+zc.buildout==2.12.2
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Products.GenericSetup',
         'ZODB3',
         'Zope2 >= 2.13',
-        'collective.indexing >= 2.0a2',
+        'collective.indexing >= 2.1',
         'collective.js.showmore',
         'lxml',
         'plone.app.content',

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -572,12 +572,6 @@ class SolrServerTests(TestCase):
         ob._setId('new_id')
         commit()
 
-        # No change in solr so far
-        self.assertEqual(search('+path_parents:\/plone\/news\/folder'), 1)
-
-        proc.reindex(self.folder, attributes=['path', ])
-        proc.commit()
-
         # Crosscheck
         self.assertEqual(search('+path_parents:\/plone\/news\/folder'), 0)
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,8 +1,8 @@
 [versions]
 
 # Buildout
-setuptools =
-zc.buildout = 2.5.0
+setuptools = 38.7.0
+zc.buildout = 2.12.2
 
 # Code Analysis
 coverage = 4.0.3


### PR DESCRIPTION
collective.indexing was not pinned to a specific version and the last version was breaking a test, which is partially redundant now.