### PR TITLE
Fix livesearch on Plone 4.3

### DIFF
--- a/src/collective/solr/browser/searchbox.pt
+++ b/src/collective/solr/browser/searchbox.pt
@@ -2,7 +2,7 @@
      i18n:domain="plone">
     <form name="searchform"
           action="search"
-          tal:attributes="action string:${view/site_url}/search">
+          tal:attributes="action string:${view/site_url}/@@search">
 
         <label for="searchGadget" class="hiddenStructure"
                     i18n:translate="text_search">Search Site</label>


### PR DESCRIPTION
With Products.CMFPlone 4.3.17, in Products/CMFPlone/skins/plone_ecmascript/livesearch.js

The livesearch fails due to the action that does not match (search instead of @@search).
Anyhow using view without @@ can conflict with objects ids.