### PR TITLE
Tests: make sure we don't have old data queued

### DIFF
--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -295,6 +295,12 @@ class SolrMaintenanceTests(TestCase):
         sm.registerAdapter(RaisingAdder,
                            required=(iface,),
                            name='Image')
+
+        manager = getUtility(ISolrConnectionManager)
+        conn = manager.getConnection()
+        # make sure we don't have old data queued
+        conn.abort()
+
         # ignore_exceptions=False should raise the handler's exception,
         # thereby aborting the reindex tx
         maintenance = self.portal.unrestrictedTraverse('solr-maintenance')


### PR DESCRIPTION
On Python 2 the test actually passes despite the old data, but on Python 3 it fails, probably because the order of the data differs.

In case we end up with separate branches I'm making this PR to master but I'm also cherry-picking to the python3 branch.