### PR TITLE
Use named behavior "solr.fields".

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.0.0a5 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Use named behavior "solr.fields" instead of "collective.solr.behaviors.ISolrFields".
+  [timo]
 
 
 8.0.0a4 (2019-11-28)

--- a/src/collective/solr/configure.zcml
+++ b/src/collective/solr/configure.zcml
@@ -71,6 +71,7 @@
       <!-- Schema extender as behavior -->
       <plone:behavior
 	  title="Solr extension"
+    name="solr.fields"
 	  description="Extra fields for Solr indexing"
 	  provides=".behaviors.ISolrFields"
 	  zcml:condition="installed plone.app.dexterity"

--- a/src/collective/solr/profiles/default/types/Collection.xml
+++ b/src/collective/solr/profiles/default/types/Collection.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="Collection"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="Collection" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/Document.xml
+++ b/src/collective/solr/profiles/default/types/Document.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="Document"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="Document" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/Event.xml
+++ b/src/collective/solr/profiles/default/types/Event.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="Event"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="Event" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/File.xml
+++ b/src/collective/solr/profiles/default/types/File.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="File"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="File" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/Folder.xml
+++ b/src/collective/solr/profiles/default/types/Folder.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="Folder"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="Folder" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/Image.xml
+++ b/src/collective/solr/profiles/default/types/Image.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="Image"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="Image" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/Link.xml
+++ b/src/collective/solr/profiles/default/types/Link.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="Link"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="Link" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>

--- a/src/collective/solr/profiles/default/types/News_Item.xml
+++ b/src/collective/solr/profiles/default/types/News_Item.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0"?>
-<object
-    name="News Item"
-    meta_type="Dexterity FTI"
-    i18n:domain="plone"
-    xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+<object name="News Item" meta_type="Dexterity FTI" i18n:domain="plone" 
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n">
 
   <property name="behaviors" purge="false">
-    <element value="collective.solr.behaviors.ISolrFields" />
+    <element value="solr.fields" />
   </property>
 
 </object>


### PR DESCRIPTION
...instead of "collective.solr.behaviors.ISolrFields".

Using the full dotted behavior path leads to a hellish amount of "could not adapt" errors in all our Plone 5.2 projects.

Without this fix collective.solr is unusable in production with Plone 5.2/Python3.