### PR TITLE
Fix index subjects with non-ascii characters.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 8.0.0a6 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix index subjects with non-ascii characters. [mathias.leimgruber]
 
 
 8.0.0a5 (2019-12-17)

--- a/plone-5.1.x.cfg
+++ b/plone-5.1.x.cfg
@@ -3,3 +3,9 @@ extends =
     base.cfg
     http://dist.plone.org/release/5.1.6/versions.cfg
     versions.cfg
+
+[versions]
+# fixes: SyntaxError: invalid syntax (more.py, line 340)
+zipp = 0.5.2
+# more-itertools >= 6.0.0 dropped python2.7 support
+more-itertools = 5.0.0

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -28,6 +28,7 @@
 # c.delete('123')
 # c.commit()
 
+from plone.dexterity.utils import safe_unicode
 import six.moves.http_client
 import socket
 from xml.etree.cElementTree import fromstring
@@ -181,7 +182,10 @@ class SolrConnection:
 
     def escapeVal(self, val):
         if not isinstance(val, six.text_type):
-            val = six.text_type(val)
+            try:
+                val = six.text_type(val)
+            except UnicodeDecodeError:
+                val = safe_unicode(val)
         if six.PY2:
             val = val.encode("utf-8")
         escaped_val = escape(val.translate(translation_map))

--- a/src/collective/solr/tests/test_subjects.py
+++ b/src/collective/solr/tests/test_subjects.py
@@ -1,0 +1,35 @@
+from collective.solr.interfaces import ISearch
+from collective.solr.testing import LEGACY_COLLECTIVE_SOLR_FUNCTIONAL_TESTING
+from collective.solr.utils import activate
+from plone import api
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.dexterity.utils import safe_unicode
+from unittest import TestCase
+from zope.component import getUtility
+import six
+import transaction
+
+
+class TestDublincoreSubjectField(TestCase):
+
+    layer = LEGACY_COLLECTIVE_SOLR_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        setRoles(self.portal, TEST_USER_ID, ["Manager"])
+
+        subjects = [safe_unicode('\xc3\xbcber Keyword'),
+                    safe_unicode('Second one')]
+
+        self.content = api.content.create(
+            container=api.portal.get(),
+            type='Document',
+            title='test document',
+            subject=subjects
+        )
+    def test_successfully_reindex_umlauts(self):
+        activate()
+        self.content.reindexObject()
+        # This failed before with a UnicodeDecodeError
+        transaction.commit()


### PR DESCRIPTION
Without any modification this test produces the following error:

```
Error in test test_umlauts (collective.solr.tests.test_subjects.TestDublincoreSubjectField)
Traceback (most recent call last):
  File "/path/to/python/parts/opt/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/path/to/pkgs/collective.solr/src/collective/solr/tests/test_subjects.py", line 27, in test_umlauts
    transaction.commit()
  File "/path/to/dotfiles/.buildout/eggs/transaction-2.4.0-py2.7.egg/transaction/_manager.py", line 252, in commit
    return self.manager.commit()
  File "/path/to/dotfiles/.buildout/eggs/transaction-2.4.0-py2.7.egg/transaction/_manager.py", line 131, in commit
    return self.get().commit()
  File "/path/to/dotfiles/.buildout/eggs/transaction-2.4.0-py2.7.egg/transaction/_transaction.py", line 296, in commit
    self._callBeforeCommitHooks()
  File "/path/to/dotfiles/.buildout/eggs/transaction-2.4.0-py2.7.egg/transaction/_transaction.py", line 367, in _callBeforeCommitHooks
    hook(*args, **kws)
  File "/path/to/dotfiles/.buildout/eggs/Products.CMFCore-2.4.0-py2.7.egg/Products/CMFCore/indexing.py", line 312, in before_commit
    self.queue.process()
  File "/path/to/dotfiles/.buildout/eggs/Products.CMFCore-2.4.0-py2.7.egg/Products/CMFCore/indexing.py", line 222, in process
    util.reindex(obj, attributes, update_metadata=metadata)
  File "/path/to/pkgs/collective.solr/src/collective/solr/indexer.py", line 261, in reindex
    self.index(obj, attributes)
  File "/path/to/pkgs/collective.solr/src/collective/solr/indexer.py", line 254, in index
    adder(conn, boost_values=boost_values(obj, data), **data)
  File "/path/to/pkgs/collective.solr/src/collective/solr/indexer.py", line 122, in __call__
    conn.add(**data)
  File "/path/to/pkgs/collective.solr/src/collective/solr/solr.py", line 284, in add
    lst.append(tmpl % self.escapeVal(value))
  File "/path/to/pkgs/collective.solr/src/collective/solr/solr.py", line 185, in escapeVal
    val = six.text_type(val)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
```


Issue:
`Subject` method defined in https://github.com/plone/plone.dexterity/blob/af8ce7925e2e24e0d7cb335413acd618ba919637/plone/dexterity/content.py#L513 returns  alist of `utf-8` strings not unicode, so it's not compatible anymore with python 2.7 deployments. 