### PR TITLE
Fix BinaryAdder for Tika.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.0.0a7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix BinaryAdder for Tika. Newer Solr versions expect json so we have to set wt=xml in the BinaryAdder.
+  [timo]
 
 
 8.0.0a6 (2020-02-28)

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -152,6 +152,7 @@ class BinaryAdder(DefaultAdder):
         )
         postdata["extractFormat"] = "text"
         postdata["extractOnly"] = "true"
+        postdata["wt"] = "xml"
 
         url = "%s/update/extract" % conn.solrBase
         try:


### PR DESCRIPTION
Newer Solr versions expect json so we have to set wt=xml in the BinaryAdder.