### PR TITLE
Correctly implement `actual_result_count` property setter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.0.0a9 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Correctly implement `actual_result_count` property setter
+  [mpeeters]
 
 
 8.0.0a8 (2020-03-24)

--- a/src/collective/solr/parser.py
+++ b/src/collective/solr/parser.py
@@ -135,9 +135,15 @@ class SolrResponse(Lazy):
         """
         return the actual_result_count
         """
+        if self._rlen is not _marker:
+            return self._rlen
         if getattr(self, "response", None):
             return int(self.response.numFound)
         return 0
+
+    @actual_result_count.setter
+    def actual_result_count(self, value):
+        self._rlen = value
 
     def __len__(self):
         if self._len is not _marker:

--- a/src/collective/solr/tests/test_parser.py
+++ b/src/collective/solr/tests/test_parser.py
@@ -167,6 +167,15 @@ class ParserTests(TestCase):
         empty_uid = [r for r in results if r.UID == ""]
         self.assertEqual(empty_uid, [])
 
+    def testParseResultsActualResultCount(self):
+        complex_xml_response = getData("complex_xml_response.txt")
+        response = SolrResponse(complex_xml_response)
+        self.assertEqual(response.actual_result_count, 2)
+        response.actual_result_count = 1
+        results = response.response  # the result set is named 'response'
+        self.assertEqual(response.actual_result_count, 1)
+        self.assertEqual(len(results), 2)
+
 
 class ParseDateHelperTests(TestCase):
     def testParseDateHelper(self):


### PR DESCRIPTION
This solve an issue with plone.app.querystring

https://github.com/plone/plone.app.querystring/blob/master/plone/app/querystring/querybuilder.py#L173