### PR TITLE
Fix `getObjPositionInParent` index by avoiding indexing null values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.0.0a11 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix `getObjPositionInParent` index by avoiding indexing null values
+  [mpeeters]
 
 
 8.0.0a10 (2020-03-25)

--- a/src/collective/solr/utils.py
+++ b/src/collective/solr/utils.py
@@ -85,6 +85,8 @@ def prepareData(data):
     path = data.get("path")
     if isinstance(path, dict) and not path.get("query"):
         data.pop("path")
+    if "getObjPositionInParent" in data and data["getObjPositionInParent"] is None:
+        data.pop("getObjPositionInParent")
 
 
 simpleTerm = compile(r"^[\w\d]+$", UNICODE)


### PR DESCRIPTION
This happen when using SolR for all queries and defining "getObjPositionInParent" as an integer index, the indexer fails due to some contents that does not have a value for this index.