### PR TITLE
Fix millisecond management while indexing dates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.0.0a12 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Fix millisecond management in datetime indexes
+  [odelaere]
 
 
 8.0.0a11 (2020-03-27)

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -69,22 +69,24 @@ def datehandler(value):
 
     if isinstance(value, DateTime):
         v = value.toZone("UTC")
-        value = "%04d-%02d-%02dT%02d:%02d:%06.3fZ" % (
+        value = "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ" % (
             v.year(),
             v.month(),
             v.day(),
             v.hour(),
             v.minute(),
-            v.second(),
+            int(v.second()),
+            v.millis() % 1000
         )
     elif isinstance(value, datetime):
         # Convert a timezone aware timetuple to a non timezone aware time
         # tuple representing utc time. Does nothing if object is not
         # timezone aware
-        value = datetime(*value.utctimetuple()[:7])
+        millis = int(value.microsecond / 1000)  # 1 second = 1 000 millis = 1 000 000 microsecond
+        value = datetime(*value.utctimetuple()[:6])
         value = "%s.%03dZ" % (
             value.strftime("%Y-%m-%dT%H:%M:%S"),
-            value.microsecond % 1000,
+            millis
         )
     elif isinstance(value, date):
         value = "%s.000Z" % value.strftime("%Y-%m-%dT%H:%M:%S")

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -132,14 +132,14 @@ class QueueIndexerTests(TestCase):
             id="zeidler",
             name="andi",
             cat="nerd",
-            timestamp=DateTime("May 11 1972 03:45 GMT"),
+            timestamp=DateTime("May 11 1972 03:45:59.999730 GMT"),
         )
         response = getData("add_response.txt")
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
         required = (
-            '<field name="timestamp" update="set">' "1972-05-11T03:45:00.000Z</field>"
+            '<field name="timestamp" update="set">' "1972-05-11T03:45:59.999Z</field>"
         )
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 
@@ -148,14 +148,14 @@ class QueueIndexerTests(TestCase):
             id="gerken",
             name="patrick",
             cat="nerd",
-            timestamp=datetime(1980, 9, 29, 14, 0o2),
+            timestamp=datetime(1980, 9, 29, 14, 0o2, 59, 999730),
         )
         response = getData("add_response.txt")
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
         required = (
-            '<field name="timestamp" update="set">' "1980-09-29T14:02:00.000Z</field>"
+            '<field name="timestamp" update="set">' "1980-09-29T14:02:59.999Z</field>"
         )
         self.assert_(str(output).find(required) > 0, '"date" data not found')
 


### PR DESCRIPTION
I had an issue in plone 4 where some dates were weirdly formatted in strformat.
This happens when the millisecond are too close to 0 or 1000. Then its faultly rounded and solr doesn't like a date like this : 2015-07-20T11:07:60.000Z (instead of 2015-07-20T11:07:59.999Z)
For this example I had this in the indexer : 
 ```
71         if isinstance(value, DateTime):
 72             v = value.toZone("UTC")
 73  ->         value = "%04d-%02d-%02dT%02d:%02d:%06.3fZ" % (
 74                 v.year(),
 75                 v.month(),
 76                 v.day(),
 77                 v.hour(),
 78                 v.minute(),
(ipdb>) v.second()
59.99973
(ipdb>) "%06.3f" % v.second()
'60.000'
```