### PR TITLE
Update default solrconfig.xml to include /suggest requestHandler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 8.0.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Update default solrconfig.xml to include /suggest requestHandler used by eea.facetednavigation autocomplete
+  [avoinea]
 
 
 8.0.0b1 (2020-06-12)

--- a/config/conf/solrconfig.xml
+++ b/config/conf/solrconfig.xml
@@ -98,4 +98,29 @@
     </lst>
   </requestHandler>
 
+  <!-- eea.facetednavigation autocomplete -->
+  <searchComponent name="suggest" class="solr.SpellCheckComponent">
+    <lst name="spellchecker">
+      <str name="name">suggest</str>
+      <str name="classname">org.apache.solr.spelling.suggest.Suggester</str>
+      <str name="lookupImpl">org.apache.solr.spelling.suggest.fst.WFSTLookupFactory</str>
+      <str name="field">Title</str>
+      <float name="threshold">0.005</float>
+      <str name="buildOnCommit">true</str>
+    </lst>
+  </searchComponent>
+
+  <requestHandler name="/suggest" class="org.apache.solr.handler.component.SearchHandler">
+     <lst name="defaults">
+      <str name="spellcheck">true</str>
+      <str name="spellcheck.dictionary">suggest</str>
+      <str name="spellcheck.count">10</str>
+      <str name="spellcheck.onlyMorePopular">true</str>
+      <str name="wt">xml</str>
+     </lst>
+     <arr name="components">
+      <str>suggest</str>
+     </arr>
+   </requestHandler>
+
 </config>


### PR DESCRIPTION
Update default solrconfig.xml to include /suggest requestHandler used by eea.facetednavigation autocomplete

See https://github.com/eea/eea.facetednavigation/blob/master/eea/facetednavigation/widgets/autocomplete/widget.py#L120