### PR TITLE
Remove all conflicting characters from forced simple search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 8.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix "AssertionError: term is not a simple search" with forced
+  simple search.
+  [csenger]
 
 
 8.4.0 (2020-09-10)

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -1701,6 +1701,11 @@ class SolrServerTests(TestCase):
         self.portal.invokeFactory("Document", id="fb", title="foo-bar")
         self.portal.invokeFactory("Document", id="fb2", title="foo bar")
         commit()
+
+        config = getConfig()
+        config.force_simple_search = True
+        config.allow_complex_search = True
+
         results = solrSearchResults(SearchableText="foo-bar")
         self.assertEqual(sorted([r.Title for r in results]), ["foo bar", "foo-bar"])
 
@@ -1708,6 +1713,11 @@ class SolrServerTests(TestCase):
         self.portal.invokeFactory("Document", id="fb", title="foo:bar")
         self.portal.invokeFactory("Document", id="fb2", title="foo bar")
         commit()
+
+        config = getConfig()
+        config.force_simple_search = True
+        config.allow_complex_search = True
+
         results = solrSearchResults(SearchableText="foo:bar")
         self.assertEqual(sorted([r.Title for r in results]), ["foo bar", "foo:bar"])
 
@@ -1715,8 +1725,25 @@ class SolrServerTests(TestCase):
         self.portal.invokeFactory("Document", id="fb", title="foo/bar")
         self.portal.invokeFactory("Document", id="fb2", title="foo bar")
         commit()
+
+        config = getConfig()
+        config.force_simple_search = True
+        config.allow_complex_search = True
+
         results = solrSearchResults(SearchableText="foo/bar")
         self.assertEqual(sorted([r.Title for r in results]), ["foo bar", "foo/bar"])
+
+    def testForcedSimpleSearchIgnoresPoint(self):
+        self.portal.invokeFactory("Document", id="fb", title="Rundschreiben Nr. 32/2017*")
+        self.portal.invokeFactory("Document", id="fb2", title="Rundschreiben Nr 32 2017*")
+        commit()
+
+        config = getConfig()
+        config.force_simple_search = True
+        config.allow_complex_search = True
+
+        results = solrSearchResults(SearchableText="Rundschreiben Nr. 32/2017*")
+        self.assertEqual(sorted([r.id for r in results]), ["fb", "fb2"])
 
     def testSimpleSearchForWildcardOnNumbers(self):
         self.folder.invokeFactory("Document", id="doc1", title="12345")

--- a/src/collective/solr/utils.py
+++ b/src/collective/solr/utils.py
@@ -100,6 +100,7 @@ def isSimpleTerm(term):
 
 
 reserved = compile(r"(AND|OR|NOT|[+\-&|!(){}\[\]^~*?:\\/]+)", UNICODE)
+notSimpleCharacters = compile(r"[^\w\d\?\*\s]+", UNICODE)
 
 
 def removeSpecialCharactersAndOperators(term):
@@ -107,7 +108,7 @@ def removeSpecialCharactersAndOperators(term):
     Remove all special operators and characters used by Solr'
     Standard Query Parser (lucene)
     """
-    return reserved.sub(" ", term)
+    return notSimpleCharacters.sub(" ", reserved.sub(" ", term))
 
 
 operators = compile(r"(.*)\s+(AND|OR|NOT)\s+", UNICODE)


### PR DESCRIPTION
Fixes "AssertionError: term is not a simple search" with certain characters.
Also fix tests