### PR TITLE
Allow search accross multiple core

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Bugfix:
   [laulaz]
   
 - Fix transaction abort on blob missing during syncing and indexing
+New Feature:
+
+- Allow search accross multiple SolR cores on the same server by using `core` parameter
+  [mpeeters]
 
 
 9.0.0a5 (2022-01-15)

--- a/src/collective/solr/dispatcher.py
+++ b/src/collective/solr/dispatcher.py
@@ -83,10 +83,13 @@ def solrSearchResults(request=None, **keywords):
         else:
             raise FallBackException
 
+    core = args.get("core", None)
     query, params = search.buildQueryAndParameters(**args)
 
     if query != {}:
         __traceback_info__ = (query, params, args)
+        if core is not None:
+            params["core"] = core
         response = search(query, **params)
     else:
         return SolrResponse()
@@ -96,7 +99,7 @@ def solrSearchResults(request=None, **keywords):
         adapter = queryMultiAdapter((flare, request), IFlare)
         return adapter is not None and adapter or flare
 
-    schema = search.getManager().getSchema() or {}
+    schema = search.getManager(core=core).getSchema() or {}
     results = response.results()
     for idx, flare in enumerate(results):
         flare = wrap(flare)

--- a/src/collective/solr/manager.py
+++ b/src/collective/solr/manager.py
@@ -37,10 +37,14 @@ class SolrConnectionManager(object):
     """a thread-local connection manager for solr"""
 
     lock = False
+    core = None
 
     def __init__(self, active=None):
         if isinstance(active, bool):
             self.setHost(active=active)
+
+    def setCore(self, core):
+        self.core = core
 
     def setHost(self, active=False, host="localhost", port=8983, base="/solr/plone"):
         """set connection parameters"""
@@ -51,15 +55,27 @@ class SolrConnectionManager(object):
         config.base = six.text_type(base)
         self.closeConnection(clearSchema=True)
 
+    @property
+    def connection_key(self):
+        if self.core:
+            return "connection_{0}".format(self.core)
+        return "connection"
+
+    @property
+    def schema_key(self):
+        if self.core:
+            return "schema_{0}".format(self.core)
+        return "schema"
+
     def closeConnection(self, clearSchema=False):
         """close the current connection, if any"""
         logger.debug("closing connection")
-        conn = getLocal("connection")
+        conn = getLocal(self.connection_key)
         if conn is not None:
             conn.close()
-            setLocal("connection", None)
+            setLocal(self.connection_key, None)
         if clearSchema:
-            setLocal("schema", None)
+            setLocal(self.schema_key, None)
 
     def getConfigParameter(self, key, env_key=None, formatter=None):
         """Return config from environment variable or by default from registry"""
@@ -77,7 +93,7 @@ class SolrConnectionManager(object):
         """returns an existing connection or opens one"""
         if not isActive():
             return None
-        conn = getLocal("connection")
+        conn = getLocal(self.connection_key)
         if conn is not None:
             return conn
 
@@ -103,7 +119,7 @@ class SolrConnectionManager(object):
                 login=config_login,
                 password=config_password,
             )
-            setLocal("connection", conn)
+            setLocal(self.connection_key, conn)
         elif config_host is not None:
             # otherwise use connection parameters defined in control panel...
             config_port = self.getConfigParameter("collective.solr.port", formatter=int)
@@ -117,12 +133,14 @@ class SolrConnectionManager(object):
                 login=config_login,
                 password=config_password,
             )
-            setLocal("connection", conn)
+            setLocal(self.connection_key, conn)
+        if self.core:  # Adapt core if it is necessary
+            conn.solrBase = "/".join(conn.solrBase.split("/")[:-1] + [self.core])
         return conn
 
     def getSchema(self):
         """returns the currently used schema or fetches it"""
-        schema = getLocal("schema")
+        schema = getLocal(self.schema_key)
         if schema is None:
             conn = self.getConnection()
             if conn is not None:
@@ -130,7 +148,7 @@ class SolrConnectionManager(object):
                 self.setSearchTimeout()
                 try:
                     schema = conn.get_schema()
-                    setLocal("schema", schema)
+                    setLocal(self.schema_key, schema)
                 except (error, CannotSendRequest, ResponseNotReady):
                     logger.exception("exception while getting schema")
         return schema

--- a/src/collective/solr/mangler.py
+++ b/src/collective/solr/mangler.py
@@ -261,7 +261,7 @@ def subtractQueryParameters(args, request_keywords=None):
         params["rows"] = int(limit)
 
     for key, value in args.copy().items():
-        if key in ("fq", "fl", "facet", "hl", "d", "pt", "sfield"):
+        if key in ("fq", "fl", "facet", "hl", "d", "pt", "sfield", "core"):
             params[key] = value
             del args[key]
         elif key.startswith("facet.") or key.startswith("facet_"):

--- a/src/collective/solr/tests/test_multicore.py
+++ b/src/collective/solr/tests/test_multicore.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+
+from collective.solr.dispatcher import solrSearchResults
+from collective.solr.interfaces import ISearch
+from collective.solr.interfaces import ISolrConnectionManager
+from collective.solr.local import getLocal
+from collective.solr.manager import SolrConnectionManager
+from collective.solr.testing import LEGACY_COLLECTIVE_SOLR_FUNCTIONAL_TESTING
+from collective.solr.testing import activateAndReindex
+from collective.solr.utils import activate
+from zope.component import getSiteManager
+from zope.component import getUtility
+from zope.component import queryUtility
+
+import unittest
+
+
+class SolrMulticoreTests(unittest.TestCase):
+    layer = LEGACY_COLLECTIVE_SOLR_FUNCTIONAL_TESTING
+
+    def _close_connections(self, keys):
+        for key in keys:
+            key = key is not None and key or ""
+            manager = getUtility(ISolrConnectionManager, name=key)
+            manager.closeConnection(clearSchema=True)
+
+    def setUp(self):
+        self.portal = self.layer["portal"]
+        self.request = self.layer["request"]
+        activateAndReindex(self.portal)
+        self._close_connections(keys=(None,))
+        sm = getSiteManager()
+        self._plone_manager = SolrConnectionManager()
+        sm.registerUtility(self._plone_manager, ISolrConnectionManager, name="plone")
+        self._foo_manager = SolrConnectionManager()
+        sm.registerUtility(self._foo_manager, ISolrConnectionManager, name="foo")
+
+    def tearDown(self):
+        activate(active=False)
+        self._close_connections((None, "plone", "foo"))
+        sm = getSiteManager()
+        sm.unregisterUtility(self._plone_manager, ISolrConnectionManager, name="plone")
+        sm.unregisterUtility(self._foo_manager, ISolrConnectionManager, name="foo")
+
+    def test_default_utility(self):
+        manager = queryUtility(ISolrConnectionManager)
+        # Default manager must not have a core parameter
+        self.assertIsNone(manager.core)
+        self.assertEqual("connection", manager.connection_key)
+        self.assertEqual("schema", manager.schema_key)
+
+    def test_named_utilities(self):
+        default_manager = queryUtility(ISolrConnectionManager)
+        default_conn = default_manager.getConnection()
+        default_schema = default_manager.getSchema()
+
+        plone_manager = queryUtility(ISolrConnectionManager, name="plone")
+        plone_manager.setCore("plone")
+        self.assertEqual("plone", plone_manager.core)
+        self.assertEqual("connection_plone", plone_manager.connection_key)
+        self.assertEqual("schema_plone", plone_manager.schema_key)
+
+        plone_conn = plone_manager.getConnection()
+        self.assertTrue(default_conn != plone_conn)
+        self.assertEqual("/solr/plone", plone_conn.solrBase)
+
+        plone_schema = plone_manager.getSchema()
+        self.assertEqual(default_schema, plone_schema)
+
+        foo_manager = queryUtility(ISolrConnectionManager, name="foo")
+        foo_manager.setCore("foo")
+        self.assertEqual("foo", foo_manager.core)
+        self.assertEqual("connection_foo", foo_manager.connection_key)
+        self.assertEqual("schema_foo", foo_manager.schema_key)
+
+        foo_conn = foo_manager.getConnection()
+        self.assertTrue(default_conn != foo_conn)
+        self.assertEqual("/solr/foo", foo_conn.solrBase)
+
+    def test_search_on_core(self):
+        # Verify that connections does not exist before search
+        self.assertIsNone(getLocal("connection"))
+        self.assertIsNone(getLocal("connection_plone"))
+
+        search = getUtility(ISearch, context=self.portal)
+        results_core = search("+Title:*Welcome to Plone*", core="plone").results()
+        self.assertEqual(1, len(results_core))
+        self.assertIsNone(getLocal("connection"))
+        self.assertIsNotNone(getLocal("connection_plone"))
+
+        results_default = search("+Title:*Welcome to Plone*").results()
+        self.assertEqual(1, len(results_default))
+
+        # Verify connections and schemas
+        default_conn = getLocal("connection")
+        plone_conn = getLocal("connection_plone")
+        self.assertTrue(default_conn != plone_conn)
+        self.assertIsNotNone(default_conn)
+        self.assertIsNotNone(plone_conn)
+
+    def test_solr_search_result_with_core(self):
+        # Verify that connections and schemas does not exist before search
+        self.assertIsNone(getLocal("connection"))
+        self.assertIsNone(getLocal("schema"))
+        self.assertIsNone(getLocal("connection_plone"))
+        self.assertIsNone(getLocal("schema_plone"))
+
+        results = solrSearchResults(
+            self.request, Title="Welcome to Plone", use_solr=True, core="plone"
+        )
+        self.assertEqual(1, len(results))
+
+        # Verify that only concerned schemas and connections are now defined
+        self.assertIsNone(getLocal("connection"))
+        self.assertIsNone(getLocal("schema"))
+        self.assertIsNotNone(getLocal("connection_plone"))
+        self.assertIsNotNone(getLocal("schema_plone"))


### PR DESCRIPTION
This PR add a new parameter `core` for SolR search that can be used to search on other SolR core from the same SoLR server.

To allow a search from a new SolR core, a new named utility must be defined for ISolrConnectionManager with the core id as name.