### PR TITLE
Fix check on inactive content permission in search results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 9.0.0a6 (unreleased)
 --------------------
 
-- Nothing changed yet.
+Bugfix:
+
+- Fix check on ``Access inactive portal content`` permission in search results.
+  It also takes local permission (ex: sharing) into account now (not only site-wide permission).
+  [laulaz]
 
 
 9.0.0a5 (2022-01-15)

--- a/src/collective/solr/monkey.py
+++ b/src/collective/solr/monkey.py
@@ -1,7 +1,6 @@
 from collective.solr.interfaces import ISearchDispatcher
 from DateTime import DateTime
-from Products.CMFCore.permissions import AccessInactivePortalContent
-from Products.CMFCore.utils import _checkPermission, _getAuthenticatedUser
+from Products.CMFCore.utils import _getAuthenticatedUser
 from Products.CMFPlone.CatalogTool import CatalogTool
 from zope.component import queryAdapter
 
@@ -12,7 +11,7 @@ def searchResults(self, REQUEST=None, **kw):
     only_active = not kw.get("show_inactive", False)
     user = _getAuthenticatedUser(self)
     kw["allowedRolesAndUsers"] = self._listAllowedRolesAndUsers(user)
-    if only_active and not _checkPermission(AccessInactivePortalContent, self):
+    if only_active and not self.allow_inactive(kw):
         kw["effectiveRange"] = DateTime()
 
     adapter = queryAdapter(self, ISearchDispatcher)


### PR DESCRIPTION
It must also take local permission (ex: sharing) into account now, not only site-wide permission.

This relates to #317.
