### PR TITLE
Fix multipart error on search

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -7,7 +7,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8]
-        black-version: ['21.11b1']
+        black-version: ["21.11b1"]
+        click-version: ["8.0.4"]
 
     steps:
       # git checkout
@@ -29,7 +30,7 @@ jobs:
 
       # install black
       - name: install black
-        run: pip install black==${{ matrix.black-version }}
+        run: pip install click==${{ matrix.click-version }} black==${{ matrix.black-version }}
 
       # run black
       - name: run black

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Changelog
 9.0.0a7 (unreleased)
 --------------------
 
-- Nothing changed yet.
+Bugfix:
+
+- Fix multipart error on search
+  [reebalazs]
 
 
 9.0.0a6 (2022-03-21)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ update: ## Update Make and Buildout
 bin/buildout: bin/pip
 	bin/pip install --upgrade pip
 	bin/pip install -r requirements.txt
-	bin/pip install black || true
+	bin/pip install click==8.0.4 black==21.10b0 || true
 	@touch -c $@
 
 bin/python bin/pip:

--- a/src/collective/solr/exceptions.py
+++ b/src/collective/solr/exceptions.py
@@ -29,3 +29,7 @@ class SolrConnectionException(SolrException):
 
     def __str__(self):
         return "HTTP code=%s, reason=%s" % (self.httpcode, self.reason)
+
+
+class RepeatableSolrConnectionException(SolrConnectionException):
+    """An exception thrown by solr connections, that can be repeated once"""

--- a/src/collective/solr/manager.py
+++ b/src/collective/solr/manager.py
@@ -118,6 +118,7 @@ class SolrConnectionManager(object):
                 persistent=True,
                 login=config_login,
                 password=config_password,
+                manager=self,
             )
             setLocal(self.connection_key, conn)
         elif config_host is not None:
@@ -132,6 +133,7 @@ class SolrConnectionManager(object):
                 persistent=True,
                 login=config_login,
                 password=config_password,
+                manager=self,
             )
             setLocal(self.connection_key, conn)
         if self.core:  # Adapt core if it is necessary


### PR DESCRIPTION
This error connection happens randomly and breaks a thread connection
permanently.

```
o.a.s.s.SolrRequestParsers Couldn't get multipart parts in order to
delete them => java.io.IOException: Missing initial multi part boundary
  at org.eclipse.jetty.util.MultiPartInputStreamParser.parse(MultiPartInputStreamParser.java:606)
java.io.IOException: Missing initial multi part boundary
```

The fix resets the connection and completely recreates it from within
the manager. (A simple connection reset is not sufficient.)

There is no evidence of what causes the issue but a reindex with many
content items breaks the connection of the thread that was doing the
reindex in a reliable way. This solution fixes this scenario.