### PR TITLE
WIP Fix reindex if an attribute is removed from an object

### DIFF
--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -286,6 +286,7 @@ class SolrIndexProcessor(object):
     def reindex(self, obj, attributes=None, update_metadata=False):
         if not attributes:
             attributes = None
+        self.unindex(obj)
         self.index(obj, attributes)
 
     def unindex(self, obj):


### PR DESCRIPTION
If an attribute becomes None, then the previous code would not have
updated the attribute value in the index and the previous value would
have lingered indefinitely.