### PR TITLE
WIP Fix reindex if an attribute is removed from an object

### DIFF
--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -316,6 +316,15 @@ class SolrConnection:
                     lst.append(tmpl % (self.escapeKey(f)))
             else:
                 lst.append(tmpl % self.escapeVal(v))
+
+        # Have to delete every missing field explicitly
+        # XXX how about other field types? Should they also be deleted with some other value (not null)?
+        #     (since something gives an error)
+        nofields = set(map(lambda field: field['name'], filter(lambda field: field['class_'] in ['solr.StrField', 'solr.TextField'], schema.fields))) - set(fields.keys())
+        for name in nofields:
+            tmpl = '<field name="%s" update="set" null="true"/>'
+            lst.append(tmpl % (self.escapeKey(name)))
+
         lst.append("</doc>")
         lst.append("</add>")
         xstr = "".join(lst)


### PR DESCRIPTION
If an attribute becomes None, then the previous code would not have
updated the attribute value in the index and the previous value would
have lingered indefinitely.

This is a second variety fix which instead of unindexing the whole
object, just removes all attributes that are not in the data.
Caveat: currently effective only on string and text field types.