### PR TITLE
Avoid java.lang.NumberFormatException in Solr when the 'rows' parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 9.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Limit `rows` to 1000000000; higher values can cause a NumberFormatException in solr.
+  [tisto, davisagli]
 
 
 9.1.0 (2023-03-07)

--- a/src/collective/solr/browser/maintenance.py
+++ b/src/collective/solr/browser/maintenance.py
@@ -240,7 +240,9 @@ class SolrMaintenanceView(BrowserView):
         cpu = timer(process_time)  # cpu time
         # get Solr status
         response = conn.search(
-            q=preImportDeleteQuery, rows=MAX_RESULTS_SUPPORTED_BY_SOLR, fl="%s modified" % key
+            q=preImportDeleteQuery,
+            rows=MAX_RESULTS_SUPPORTED_BY_SOLR,
+            fl="%s modified" % key,
         )
         # avoid creating DateTime instances
         simple_unmarshallers = unmarshallers.copy()

--- a/src/collective/solr/browser/maintenance.py
+++ b/src/collective/solr/browser/maintenance.py
@@ -9,6 +9,7 @@ from collective.solr.interfaces import (
     ISolrAddHandler,
     ISolrConnectionManager,
     ISolrMaintenanceView,
+    MAX_RESULTS_SUPPORTED_BY_SOLR,
 )
 from collective.solr.parser import SolrResponse, parse_date_as_datetime, unmarshallers
 from collective.solr.utils import findObjects, prepareData
@@ -19,7 +20,6 @@ from zope.component import queryAdapter, queryUtility
 from zope.interface import implementer
 
 logger = getLogger("collective.solr.maintenance")
-MAX_ROWS = 1000000000
 
 
 try:
@@ -240,7 +240,7 @@ class SolrMaintenanceView(BrowserView):
         cpu = timer(process_time)  # cpu time
         # get Solr status
         response = conn.search(
-            q=preImportDeleteQuery, rows=MAX_ROWS, fl="%s modified" % key
+            q=preImportDeleteQuery, rows=MAX_RESULTS_SUPPORTED_BY_SOLR, fl="%s modified" % key
         )
         # avoid creating DateTime instances
         simple_unmarshallers = unmarshallers.copy()

--- a/src/collective/solr/interfaces.py
+++ b/src/collective/solr/interfaces.py
@@ -6,6 +6,10 @@ from zope.schema.interfaces import IVocabularyFactory
 from collective.solr import SolrMessageFactory as _
 
 
+# If we send too large a number to solr, it can't parse it
+MAX_RESULTS_SUPPORTED_BY_SOLR = 1_000_000_000
+
+
 class ISolrSchema(Interface):
 
     active = Bool(
@@ -121,7 +125,8 @@ class ISolrSchema(Interface):
             "ridiculously large value that is higher than the "
             "possible number of rows that are expected.",
         ),
-        default=1000000,
+        default=1_000_000,
+        max=MAX_RESULTS_SUPPORTED_BY_SOLR,
     )
 
     required = List(

--- a/src/collective/solr/mangler.py
+++ b/src/collective/solr/mangler.py
@@ -2,6 +2,12 @@ from datetime import date, datetime
 
 import six
 from AccessControl import getSecurityManager
+from DateTime import DateTime
+from plone.registry.interfaces import IRegistry
+from pytz import timezone
+from six.moves import map
+from zope.component import getUtility
+
 from collective.solr.queryparser import quote
 from collective.solr.utils import (
     getConfig,
@@ -11,11 +17,6 @@ from collective.solr.utils import (
     removeSpecialCharactersAndOperators,
     splitSimpleSearch,
 )
-from DateTime import DateTime
-from plone.registry.interfaces import IRegistry
-from pytz import timezone
-from six.moves import map
-from zope.component import getUtility
 
 ranges = {
     "min": "[%s TO *]",
@@ -256,6 +257,7 @@ def subtractQueryParameters(args, request_keywords=None):
         order = reverse and "desc" or "asc"
         params["sort"] = "%s %s" % (index, order)
 
+    breakpoint()
     limit = get("limit")
     if limit:
         params["rows"] = int(limit)

--- a/src/collective/solr/mangler.py
+++ b/src/collective/solr/mangler.py
@@ -257,7 +257,6 @@ def subtractQueryParameters(args, request_keywords=None):
         order = reverse and "desc" or "asc"
         params["sort"] = "%s %s" % (index, order)
 
-    breakpoint()
     limit = get("limit")
     if limit:
         params["rows"] = int(limit)

--- a/src/collective/solr/search.py
+++ b/src/collective/solr/search.py
@@ -9,7 +9,11 @@ from zope.component import queryUtility
 from zope.interface import implementer
 
 from collective.solr.exceptions import SolrInactiveException
-from collective.solr.interfaces import ISearch, ISolrConnectionManager, MAX_RESULTS_SUPPORTED_BY_SOLR
+from collective.solr.interfaces import (
+    ISearch,
+    ISolrConnectionManager,
+    MAX_RESULTS_SUPPORTED_BY_SOLR,
+)
 from collective.solr.mangler import (
     cleanupQueryParameters,
     mangleQuery,
@@ -58,7 +62,7 @@ class Search(object):
         sow="true",
         lowercase_operator="true",
         default_operator="AND",
-        **parameters
+        **parameters,
     ):
         """perform a search with the given querystring and parameters"""
         start = time()
@@ -98,8 +102,9 @@ class Search(object):
                 if rows > MAX_RESULTS_SUPPORTED_BY_SOLR:
                     logger.warning(
                         'The "rows" parameter was set to "%s" but automatically limited '
-                        ' to %s to avoid a Solr java.lang.NumberFormatException',
-                        parameters["rows"], MAX_RESULTS_SUPPORTED_BY_SOLR
+                        " to %s to avoid a Solr java.lang.NumberFormatException",
+                        parameters["rows"],
+                        MAX_RESULTS_SUPPORTED_BY_SOLR,
                     )
                     parameters["rows"] = MAX_RESULTS_SUPPORTED_BY_SOLR
         if getattr(config, "highlight_fields", None):
@@ -117,7 +122,7 @@ class Search(object):
             else:
                 parameters["fl"] = "* score"
         if isinstance(query, dict):
-            query = u" ".join([safe_unicode(val) for val in query.values()])
+            query = " ".join([safe_unicode(val) for val in query.values()])
         logger.debug("searching for %r (%r)", query, parameters)
         if "sort" in parameters:  # issue warning for unknown sort indices
             index, order = parameters["sort"].split()

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -39,14 +39,15 @@ import six
 import six.moves.http_client
 import six.moves.urllib.parse
 import six.moves.urllib.request
+from plone.dexterity.utils import safe_unicode
+from requests_toolbelt import MultipartEncoder
+
 from collective.solr.exceptions import (
-    SolrConnectionException,
     RepeatableSolrConnectionException,
+    SolrConnectionException,
 )
 from collective.solr.parser import SolrSchema
 from collective.solr.utils import getConfig, translation_map
-from plone.dexterity.utils import safe_unicode
-from requests_toolbelt import MultipartEncoder
 
 logger = getLogger(__name__)
 

--- a/src/collective/solr/tests/test_mangler.py
+++ b/src/collective/solr/tests/test_mangler.py
@@ -1,6 +1,10 @@
 from datetime import datetime
 from unittest import TestCase
 
+from DateTime import DateTime
+from pytz import timezone
+from zope.component import getGlobalSiteManager, provideUtility
+
 from collective.solr.interfaces import ISolrConnectionConfig
 from collective.solr.mangler import (
     cleanupQueryParameters,
@@ -11,9 +15,6 @@ from collective.solr.mangler import (
 from collective.solr.parser import SolrField, SolrSchema
 from collective.solr.testing import COLLECTIVE_SOLR_MOCK_REGISTRY_FIXTURE
 from collective.solr.utils import getConfig
-from DateTime import DateTime
-from pytz import timezone
-from zope.component import getGlobalSiteManager, provideUtility
 
 
 def mangle(**keywords):

--- a/src/collective/solr/tests/test_server.py
+++ b/src/collective/solr/tests/test_server.py
@@ -1194,6 +1194,17 @@ class SolrServerTests(TestCase):
         self.assertEqual(results.numFound, str(len(DEFAULT_OBJS)))
         self.assertEqual(len(results), 5)
 
+    def testLimitSearchResultsAvoidSolrException(self):
+        # Solr raises a java.lang.NumberFormatException
+        # when the rows parameter is more than 3000000000 (roughly)
+        # in that case we set the any value higher than 1.000.000.000
+        # to 1.000.000.000
+        self.maintenance.reindex()
+        # not raising an exception here means success
+        self.assertTrue(
+            self.search("+path_parents:\\/plone", rows=3000000000).results()
+        )
+
     def testSortParameters(self):
         self.maintenance.reindex()
 


### PR DESCRIPTION
…er exceeds a certain value. This fixes #357