### PR TITLE
Fix indexing of set values in multivalue fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix indexing of set values in multivalue fields [reebalazs]
 
 
 9.1.2 (2023-03-20)

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -407,6 +407,8 @@ class SolrIndexProcessor(object):
             except Exception:
                 logger.exception("Error occured while getting data for indexing!")
                 continue
+            if isinstance(value, set):
+                value = list(value)
             field = schema[name]
             handler = handlers.get(field.class_, None)
             if handler is not None:

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -243,6 +243,71 @@ class QueueIndexerTests(TestCase):
         required = '<field name="image_scales" update="set">{"key": "value"}</field>'
         self.assert_(str(output).find(required) > 0, '"image_scales" data not found')
 
+    def testListIndexing(self):
+        foo = Foo(
+            id="zeidler",
+            name="andi",
+            cat=["rock", "paper", "Sharp scissors"],
+        )
+        response = getData("add_response.txt")
+        # fake add response
+        output = fakehttp(self.mngr.getConnection(), response)
+        self.proc.index(foo)
+        required1 = '<field name="cat" update="set">rock</field>'
+        required2 = '<field name="cat" update="set">paper</field>'
+        required3 = '<field name="cat" update="set">Sharp scissors</field>'
+        self.assert_(str(output).find(required1) > 0, "Some element (rock) not found")
+        self.assert_(str(output).find(required2) > 0, "Some element (paper) not found")
+        self.assert_(
+            str(output).find(required3) > 0, "Some element (Sharp scissors) not found"
+        )
+
+    def testTupleIndexing(self):
+        foo = Foo(
+            id="zeidler",
+            name="andi",
+            cat=('rock', 'paper', 'Sharp scissors'),
+        )
+        response = getData("add_response.txt")
+        # fake add response
+        output = fakehttp(self.mngr.getConnection(), response)
+        self.proc.index(foo)
+        required1 = (
+            '<field name="cat" update="set">rock</field>'
+        )
+        required2 = (
+            '<field name="cat" update="set">paper</field>'
+        )
+        required3 = (
+            '<field name="cat" update="set">Sharp scissors</field>'
+        )
+        self.assert_(str(output).find(required1) > 0, 'Some element (rock) not found')
+        self.assert_(str(output).find(required2) > 0, 'Some element (paper) not found')
+        self.assert_(str(output).find(required3) > 0, 'Some element (Sharp scissors) not found')
+
+    def testSetIndexing(self):
+        foo = Foo(
+            id="zeidler",
+            name="andi",
+            cat={'rock', 'paper', 'Sharp scissors'},
+        )
+        response = getData("add_response.txt")
+        # fake add response
+        output = fakehttp(self.mngr.getConnection(), response)
+        self.proc.index(foo)
+        required1 = (
+            '<field name="cat" update="set">rock</field>'
+        )
+        required2 = (
+            '<field name="cat" update="set">paper</field>'
+        )
+        required3 = (
+            '<field name="cat" update="set">Sharp scissors</field>'
+        )
+        self.assert_(str(output).find(required1) > 0, 'Some element (rock) not found')
+        self.assert_(str(output).find(required2) > 0, 'Some element (paper) not found')
+        self.assert_(str(output).find(required3) > 0, 'Some element (Sharp scissors) not found')
+
 
 class RobustnessTests(TestCase):
 

--- a/src/collective/solr/tests/test_indexer.py
+++ b/src/collective/solr/tests/test_indexer.py
@@ -266,47 +266,39 @@ class QueueIndexerTests(TestCase):
         foo = Foo(
             id="zeidler",
             name="andi",
-            cat=('rock', 'paper', 'Sharp scissors'),
+            cat=("rock", "paper", "Sharp scissors"),
         )
         response = getData("add_response.txt")
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required1 = (
-            '<field name="cat" update="set">rock</field>'
+        required1 = '<field name="cat" update="set">rock</field>'
+        required2 = '<field name="cat" update="set">paper</field>'
+        required3 = '<field name="cat" update="set">Sharp scissors</field>'
+        self.assert_(str(output).find(required1) > 0, "Some element (rock) not found")
+        self.assert_(str(output).find(required2) > 0, "Some element (paper) not found")
+        self.assert_(
+            str(output).find(required3) > 0, "Some element (Sharp scissors) not found"
         )
-        required2 = (
-            '<field name="cat" update="set">paper</field>'
-        )
-        required3 = (
-            '<field name="cat" update="set">Sharp scissors</field>'
-        )
-        self.assert_(str(output).find(required1) > 0, 'Some element (rock) not found')
-        self.assert_(str(output).find(required2) > 0, 'Some element (paper) not found')
-        self.assert_(str(output).find(required3) > 0, 'Some element (Sharp scissors) not found')
 
     def testSetIndexing(self):
         foo = Foo(
             id="zeidler",
             name="andi",
-            cat={'rock', 'paper', 'Sharp scissors'},
+            cat={"rock", "paper", "Sharp scissors"},
         )
         response = getData("add_response.txt")
         # fake add response
         output = fakehttp(self.mngr.getConnection(), response)
         self.proc.index(foo)
-        required1 = (
-            '<field name="cat" update="set">rock</field>'
+        required1 = '<field name="cat" update="set">rock</field>'
+        required2 = '<field name="cat" update="set">paper</field>'
+        required3 = '<field name="cat" update="set">Sharp scissors</field>'
+        self.assert_(str(output).find(required1) > 0, "Some element (rock) not found")
+        self.assert_(str(output).find(required2) > 0, "Some element (paper) not found")
+        self.assert_(
+            str(output).find(required3) > 0, "Some element (Sharp scissors) not found"
         )
-        required2 = (
-            '<field name="cat" update="set">paper</field>'
-        )
-        required3 = (
-            '<field name="cat" update="set">Sharp scissors</field>'
-        )
-        self.assert_(str(output).find(required1) > 0, 'Some element (rock) not found')
-        self.assert_(str(output).find(required2) > 0, 'Some element (paper) not found')
-        self.assert_(str(output).find(required3) > 0, 'Some element (Sharp scissors) not found')
 
 
 class RobustnessTests(TestCase):


### PR DESCRIPTION
Set value should be handled in the same way as list or tuple values. This fixes indexing for multivalue fields which serialize as sets.

Also retro-add some tests for tuple and list values.