### PR TITLE
Strip standalone wildcards from the searchable text (#362)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Strip standalone wildcards from the searchable text (#362) [reebalazs]
 
 
 9.1.3 (2023-04-11)

--- a/src/collective/solr/tests/test_query.py
+++ b/src/collective/solr/tests/test_query.py
@@ -64,6 +64,9 @@ class QuoteTests(TestCase):
         self.assertEqual(quote("?test", prefix_wildcard=True), "?test")
         self.assertEqual(quote("**test", prefix_wildcard=True), "*test")
         self.assertEqual(quote("??test", prefix_wildcard=True), "?test")
+        ## standalone wildcard stripped
+        self.assertEqual(quote("*"), "")
+        self.assertEqual(quote("**"), "")
 
     def testQuotingFuzzySearches(self):
         self.assertEqual(quote("roam~"), "roam~")

--- a/src/collective/solr/tests/test_utils.py
+++ b/src/collective/solr/tests/test_utils.py
@@ -126,6 +126,11 @@ class UtilsTests(TestCase):
         )
         self.assertRaises(AssertionError, splitSimpleSearch, "foo AND bar")
         self.assertEqual(splitSimpleSearch("foo 42"), ["foo", "42"])
+        # standalone wildcard stripped
+        self.assertEqual(splitSimpleSearch("foo *"), ["foo"])
+        self.assertEqual(splitSimpleSearch("foo **"), ["foo"])
+        # connected wildcard not stripped
+        self.assertEqual(splitSimpleSearch("foo**"), ["foo**"])
 
     def testIsWildCard(self):
         self.assertTrue(isWildCard("foo*"))

--- a/src/collective/solr/utils.py
+++ b/src/collective/solr/utils.py
@@ -152,7 +152,12 @@ def splitSimpleSearch(term):
     for i in range(0, len(parts)):
         if i % 2 == 0:
             # unquoted text
-            words = [word for word in parts[i].split() if word]
+            # note, make sure that both empty words and standalone wildcards are omitted
+            words = [
+                word
+                for word in parts[i].split()
+                if word and word != "*" and word != "**"
+            ]
             tokens.extend(words)
         else:
             # The uneven parts are those inside quotes.


### PR DESCRIPTION
Fix the problem and make "foo **" result in the same query as "foo". Without the fix this used to cause an 500 Internal Server Error.

One might argue that "foo **"  is not a valid query, to start with. However it can be expected as an input, thus it should not cause a cryptic error anyway. The fix causes to yield the expected results by stripping out the standalone wildcard.