### PR TITLE
Prevent wildcard expressions for stopwords in simple expressions

### DIFF
--- a/src/collective/solr/interfaces.py
+++ b/src/collective/solr/interfaces.py
@@ -11,7 +11,6 @@ MAX_RESULTS_SUPPORTED_BY_SOLR = 1_000_000_000
 
 
 class ISolrSchema(Interface):
-
     active = Bool(
         title=_("label_active", default="Active"),
         description=_(
@@ -386,6 +385,41 @@ class ISolrSchema(Interface):
             default="Field that Tika uses to add the extracted text to.",
         ),
         default="content",
+        required=False,
+    )
+
+    stopwords = Text(
+        title=_("label_stopwords", default="Stopwords in the format of stopwords.txt"),
+        description=_(
+            "help_stopwords",
+            default="Copy the stopwords.txt file here. "
+            "Check Solr configuration to understand the format. - "
+            "Stopwords will not get (word OR word*) simple "
+            "expression, only (word). "
+            "Notes: "
+            "1. This will only work for multi word queries "
+            "when force_simple_expression=True. - "
+            "2. It's still necessary to filter stopwords from "
+            "Solr, this option only causes the "
+            "faulty (stopword*) parts removed from "
+            "the expression ",
+        ),
+        default="",
+        required=False,
+    )
+
+    stopwords_case_insensitive = Bool(
+        title=_(
+            "label_stopwords_case_insensitive", default="Stopwords are case insensitive"
+        ),
+        description=_(
+            "help_stopwords_are_case_insensitive",
+            default="Stopwords are case insensitive "
+            "This depends on your Solr setup. If your stopwords are processed in a case insensitive way, "
+            "this should be checked and it will apply the stopword wildcard removal in a case "
+            "insensitive way.",
+        ),
+        default=False,
         required=False,
     )
 

--- a/src/collective/solr/profiles/default/registry.xml
+++ b/src/collective/solr/profiles/default/registry.xml
@@ -1,6 +1,8 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <registry>
-  <records interface="collective.solr.interfaces.ISolrSchema" prefix="collective.solr">
+  <records interface="collective.solr.interfaces.ISolrSchema"
+           prefix="collective.solr"
+  >
     <value key="active">False</value>
     <value key="host">127.0.0.1</value>
     <value key="port">8983</value>
@@ -10,7 +12,8 @@
     <value key="max_results">10000000</value>
     <value key="exclude_user">False
     </value>
-    <value key="search_pattern">+(Title:{value}^5 OR Description:{value}^2 OR SearchableText:{value} OR SearchableText:({base_value}) OR searchwords:({base_value})^1000) -showinsearch:False
+    <value key="search_pattern">+(Title:{value}^5 OR Description:{value}^2 OR SearchableText:{value}
+      OR SearchableText:({base_value}) OR searchwords:({base_value})^1000) -showinsearch:False
     </value>
     <value key="prefix_wildcard">False</value>
     <value key="force_simple_search">False</value>
@@ -25,10 +28,22 @@
     <value key="filter_queries">
       <element>portal_type</element>
     </value>
-    <value key="boost_script"></value>
-    <value key="solr_login"></value>
-    <value key="solr_password"></value>
+    <value key="boost_script" />
+    <value key="solr_login" />
+    <value key="solr_password" />
     <value key="use_tika">False</value>
     <value key="tika_default_field">content</value>
+    <!-- Stopwords will not get (word OR word*) simple expression, only (word).
+         Notes:
+         1. This will only work for multi word queries when force_simple_expression=True
+         2. It's still necessary to filter stopwords from Solr, this option only causes the
+            faulty (stopword*) parts removed from the expression.
+
+        This removal is by default case sensitive, but it can be made case insensitive. Use
+        this if you handle your stopwords in a case insensitive way. This depends on your
+        solr configuration.
+  -->
+    <value key="stopwords_case_insensitive">False</value>
+    <value key="stopwords" />
   </records>
 </registry>

--- a/src/collective/solr/stopword.py
+++ b/src/collective/solr/stopword.py
@@ -1,0 +1,45 @@
+import re
+
+from collective.solr.utils import getConfig
+
+reLine = re.compile(r"^([A-Za-zÀ-ÖØ-öø-ÿ]*)")
+
+raw = None
+raw_case_insensitive = None
+cooked = None
+
+
+def parseStopwords(stopwords, stopwords_case_insensitive):
+    return list(
+        map(
+            lambda word: word.lower() if stopwords_case_insensitive else word,
+            filter(
+                lambda word: word,
+                map(lambda line: reLine.match(line).group(1), stopwords.splitlines()),
+            ),
+        )
+    )
+
+
+def getStopWords(config):
+    global raw
+    global cooked
+    global raw_case_insensitive
+    config = config or getConfig()
+    stopwords = getattr(config, "stopwords", "") or ""
+    stopwords_case_insensitive = getattr(config, "stopwords_case_insensitive", False)
+    if (
+        cooked is None
+        or raw is not stopwords
+        or raw_case_insensitive != stopwords_case_insensitive
+    ):
+        raw = stopwords
+        raw_case_insensitive = stopwords_case_insensitive
+        cooked = parseStopwords(raw, stopwords_case_insensitive)
+    return cooked
+
+
+def isStopWord(term, config):
+    stopwords_case_insensitive = getattr(config, "stopwords_case_insensitive", False)
+    stopwords = getStopWords(config)
+    return (term.lower() if stopwords_case_insensitive else term) in stopwords

--- a/src/collective/solr/testing.py
+++ b/src/collective/solr/testing.py
@@ -84,7 +84,6 @@ SOLR_FIXTURE = SolrLayer()
 
 
 class CollectiveSolrLayer(PloneSandboxLayer):
-
     defaultBases = (PLONE_FIXTURE,)
 
     def __init__(
@@ -92,9 +91,9 @@ class CollectiveSolrLayer(PloneSandboxLayer):
         bases=None,
         name="Collective Solr Layer",
         module=None,
-        solr_host=u"localhost",
+        solr_host="localhost",
         solr_port=8983,
-        solr_base=u"/solr/plone",
+        solr_base="/solr/plone",
         solr_active=False,
     ):
         super(PloneSandboxLayer, self).__init__(bases, name, module)
@@ -136,7 +135,7 @@ class CollectiveSolrLayer(PloneSandboxLayer):
     def tearDownPloneSite(self, portal):
         set_registry_record("collective.solr.active", False)
         set_registry_record("collective.solr.port", 8983)
-        set_registry_record("collective.solr.base", u"/solr/plone")
+        set_registry_record("collective.solr.base", "/solr/plone")
         self.solr_layer.tearDown()
 
 
@@ -180,7 +179,7 @@ def activateAndReindex(portal):
 class CollectiveSolrMockRegistry(object):
     def __init__(self):
         self.active = False
-        self.host = u"localhost"
+        self.host = "localhost"
         self.port = None
         self.base = None
         self.async_indexing = False
@@ -198,9 +197,11 @@ class CollectiveSolrMockRegistry(object):
         self.exclude_user = False
         self.field_list = []
         self.atomic_updates = False
-        self.boost_script = u""
+        self.boost_script = ""
         self.solr_login = None
         self.solr_password = None
+        self.stopwords = ""
+        self.stopwords_case_insensitive = False
 
     def __getitem__(self, name):
         name_parts = name.split(".")
@@ -241,7 +242,7 @@ class CollectiveSolrMockRegistryLayer(Layer):
 
     def setUp(self):
         provideUtility(
-            provides=IRegistry, component=CollectiveSolrMockRegistry(), name=u""
+            provides=IRegistry, component=CollectiveSolrMockRegistry(), name=""
         )
 
     def tearDown(self):

--- a/src/collective/solr/tests/test_stopwords.py
+++ b/src/collective/solr/tests/test_stopwords.py
@@ -1,0 +1,132 @@
+from unittest import TestCase
+
+from zope.component import getGlobalSiteManager, provideUtility
+
+from collective.solr.interfaces import ISolrConnectionConfig
+from collective.solr.testing import COLLECTIVE_SOLR_MOCK_REGISTRY_FIXTURE
+from collective.solr.utils import getConfig
+from collective.solr.stopword import isStopWord
+import collective.solr.stopword
+from unittest import mock
+
+
+@mock.patch("collective.solr.stopword.raw", None)
+@mock.patch("collective.solr.stopword.raw_case_insensitive", None)
+@mock.patch("collective.solr.stopword.cooked", None)
+class StopwordsUtilTests(TestCase):
+    layer = COLLECTIVE_SOLR_MOCK_REGISTRY_FIXTURE
+
+    def setUp(self):
+        self.config = getConfig()
+        self.config.force_simple_search = True
+        self.config.stopwords_case_insensitive = False
+        self.config.stopwords = """stopone
+stoptwo
+"""
+        provideUtility(self.config, ISolrConnectionConfig)
+
+    def tearDown(self):
+        gsm = getGlobalSiteManager()
+        gsm.unregisterUtility(self.config, ISolrConnectionConfig)
+
+    def testIsStopword(self):
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertTrue(isStopWord("stoptwo", self.config))
+        self.assertFalse(isStopWord("stopthree", self.config))
+
+    def testCachingPreserves(self):
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertTrue(isStopWord("stoptwo", self.config))
+        self.assertFalse(isStopWord("stopthree", self.config))
+        collective.solr.stopword.cooked = ["stopone", "stopthree"]
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertFalse(isStopWord("stoptwo", self.config))
+        self.assertTrue(isStopWord("stopthree", self.config))
+
+    def testCachingUpdates(self):
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertTrue(isStopWord("stoptwo", self.config))
+        self.assertFalse(isStopWord("stopthree", self.config))
+        self.config.stopwords = """stopone
+stopthree
+"""
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertFalse(isStopWord("stoptwo", self.config))
+        self.assertTrue(isStopWord("stopthree", self.config))
+
+    def testCachingCaseInsensitivityUpdates(self):
+        self.config.stopwords = """Stopone
+Stoptwo
+"""
+        self.config.stopwords_case_insensitive = True
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertTrue(isStopWord("stoptwo", self.config))
+        self.assertFalse(isStopWord("stopthree", self.config))
+        self.config.stopwords_case_insensitive = False
+        self.assertTrue(isStopWord("Stopone", self.config))
+        self.assertTrue(isStopWord("Stoptwo", self.config))
+        self.assertFalse(isStopWord("Stopthree", self.config))
+
+    def testUnicode(self):
+        self.config.stopwords = """für
+daß
+"""
+        self.assertTrue(isStopWord("für", self.config))
+        self.assertTrue(isStopWord("daß", self.config))
+
+    def testCases(self):
+        self.config.stopwords = """Uppercase
+CamelCase
+FULLCAPS
+"""
+        self.assertTrue(isStopWord("Uppercase", self.config))
+        self.assertTrue(isStopWord("CamelCase", self.config))
+        self.assertTrue(isStopWord("FULLCAPS", self.config))
+
+    def testCaseInsensitive(self):
+        self.config.stopwords = """Uppercase
+CamelCase
+FULLCAPS
+"""
+        self.config.stopwords_case_insensitive = True
+        self.assertTrue(isStopWord("Uppercase", self.config))
+        self.assertTrue(isStopWord("CamelCase", self.config))
+        self.assertTrue(isStopWord("FULLCAPS", self.config))
+        self.assertTrue(isStopWord("uppercase", self.config))
+        self.assertTrue(isStopWord("camelcase", self.config))
+        self.assertTrue(isStopWord("fullcaps", self.config))
+        self.assertTrue(isStopWord("uppercasE", self.config))
+        self.assertTrue(isStopWord("CAMELCASE", self.config))
+        self.assertTrue(isStopWord("fullcaps", self.config))
+
+    def testEmptyLines(self):
+        self.config.stopwords = (
+            """
+
+stopone
+
+"""
+            + "   \n"
+        )
+        self.assertFalse(isStopWord("", self.config))
+        self.assertFalse(isStopWord("   ", self.config))
+        self.assertTrue(isStopWord("stopone", self.config))
+
+    def testComments(self):
+        self.config.stopwords = """stopone
+stoptwo              | nostopone
+| nostoptwo
+stopthree            # nostopthree
+# nostopfour
+"""
+        self.assertFalse(isStopWord("nostopone", self.config))
+        self.assertFalse(isStopWord(" nostopone", self.config))
+        self.assertFalse(isStopWord("nostoptwo", self.config))
+        self.assertFalse(isStopWord(" nostoptwo", self.config))
+        self.assertFalse(isStopWord("nostopthree", self.config))
+        self.assertFalse(isStopWord(" nostopthree", self.config))
+        self.assertFalse(isStopWord("nostopfour", self.config))
+        self.assertFalse(isStopWord(" nostopfour", self.config))
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertTrue(isStopWord("stoptwo", self.config))
+        self.assertTrue(isStopWord("stopthree", self.config))


### PR DESCRIPTION
- add stopwords to registry
- support function for getting the stopwords
- cache to optimize the parsing of stopwords.txt

This transforms the (term AND term*) expression for stopwords, removing the wildcard expression. Such an expression would never match any documents, because solr won't remove the wildcard term, but the  stopword will be missing from the index. This workaround does that with no side effects, as stopwords would be ignored by solr anyway.