### PR TITLE
Fix indexing of null values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix indexing of null values [reebalazs]
 
 
 9.2.0 (2024-01-31)

--- a/src/collective/solr/solr.py
+++ b/src/collective/solr/solr.py
@@ -284,7 +284,6 @@ class SolrConnection:
             lst.append("<doc>")
 
         for f, v in fields.items():
-
             # Add update="set" attribute to each field except for the uniqueKey
             # field.
             if f == uniqueKey:
@@ -316,7 +315,16 @@ class SolrConnection:
                     tmpl = '<field name="%s" update="set" null="true"/>'
                     lst.append(tmpl % (self.escapeKey(f)))
             else:
-                lst.append(tmpl % self.escapeVal(v))
+                if v is None:
+                    if f in boost_values:
+                        tmpl = '<field name="%s" boost="%s" update="set" null="true"/>'
+                        tmpl = tmpl % (self.escapeKey(f), boost_values[f])
+                    else:
+                        tmpl = '<field name="%s" update="set" null="true"/>'
+                        tmpl = tmpl % (self.escapeKey(f))
+                    lst.append(tmpl)
+                else:
+                    lst.append(tmpl % self.escapeVal(v))
         lst.append("</doc>")
         lst.append("</add>")
         xstr = "".join(lst)

--- a/src/collective/solr/tests/data/add_request_with_none.txt
+++ b/src/collective/solr/tests/data/add_request_with_none.txt
@@ -1,0 +1,7 @@
+POST /solr/plone/update HTTP/1.1
+Host: localhost
+Accept-Encoding: identity
+Content-Length: 95
+Content-Type: text/xml; charset=utf-8
+
+<add><doc><field name="id">500</field><field name="name" update="set" null="true"/></doc></add>

--- a/src/collective/solr/tests/data/add_request_with_none_and_boost_value.txt
+++ b/src/collective/solr/tests/data/add_request_with_none_and_boost_value.txt
@@ -1,0 +1,7 @@
+POST /solr/plone/update HTTP/1.1
+Host: localhost
+Accept-Encoding: identity
+Content-Length: 115
+Content-Type: text/xml; charset=utf-8
+
+<add><doc boost="2"><field name="id">500</field><field name="name" boost="5" update="set" null="true"/></doc></add>

--- a/src/collective/solr/tests/test_solr.py
+++ b/src/collective/solr/tests/test_solr.py
@@ -8,7 +8,6 @@ from collective.solr.utils import getConfig
 
 
 class TestSolr(TestCase):
-
     layer = COLLECTIVE_SOLR_MOCK_REGISTRY_FIXTURE
 
     def test_add(self):
@@ -57,6 +56,58 @@ class TestSolr(TestCase):
             atomic_updates=False,  # Force disabling atomic updates
             id="500",
             name="python test doc",
+        )
+
+        res = c.flush()
+        self.assertEqual(len(res), 1)  # one request was sent
+        self.failUnlessEqual(str(output), add_request.decode("utf-8"))
+
+    def test_add_none(self):
+        config = getConfig()
+        config.atomic_updates = True
+        add_request = getData("add_request_with_none.txt").rstrip(b"\n")
+        add_response = getData("add_response.txt")
+
+        c = SolrConnection(host="localhost:8983", persistent=True)
+
+        # fake schema response - caches the schema
+        fakehttp(c, getData("schema.xml"))
+        c.get_schema()
+
+        output = fakehttp(c, add_response)
+        c.add(id=500, name=None)
+        res = c.flush()
+        self.assertEqual(len(res), 1)  # one request was sent
+        res = res[0]
+        self.failUnlessEqual(str(output), add_request.decode("utf-8"))
+        # Status
+        node = res.findall(".//int")[0]
+        self.failUnlessEqual(node.attrib["name"], "status")
+        self.failUnlessEqual(node.text, "0")
+        # QTime
+        node = res.findall(".//int")[1]
+        self.failUnlessEqual(node.attrib["name"], "QTime")
+        self.failUnlessEqual(node.text, "4")
+        res.find("QTime")
+
+    def test_add_none_with_boost_values(self):
+        config = getConfig()
+        config.atomic_updates = False
+        add_request = getData("add_request_with_none_and_boost_value.txt").rstrip(b"\n")
+        add_response = getData("add_response.txt")
+        c = SolrConnection(host="localhost:8983", persistent=True)
+
+        # fake schema response - caches the schema
+        fakehttp(c, getData("schema.xml"))
+        c.get_schema()
+
+        output = fakehttp(c, add_response)
+        boost = {"": 2, "id": 0.5, "name": 5}
+        c.add(
+            boost_values=boost,
+            atomic_updates=False,  # Force disabling atomic updates
+            id="500",
+            name=None,
         )
 
         res = c.flush()


### PR DESCRIPTION
This is very surprising, but it looks like solr lacked the support for missing (None) values, so they got degraded to a "None" string. This PR adds the condition that fixes it.

Supporting None values was already added earlier for lists (multi values), but not for the simple index use case.