### PR TITLE
Allow leading spaces in the stopwords configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow leading spaces in the stopwords configuration [reebalazs]
 
 
 9.2.1 (2024-02-01)

--- a/src/collective/solr/stopword.py
+++ b/src/collective/solr/stopword.py
@@ -2,7 +2,7 @@ import re
 
 from collective.solr.utils import getConfig
 
-reLine = re.compile(r"^([A-Za-zÀ-ÖØ-öø-ÿ]*)")
+reLine = re.compile(r"^\s*([A-Za-zÀ-ÖØ-öø-ÿ]*)")
 
 raw = None
 raw_case_insensitive = None

--- a/src/collective/solr/tests/test_stopwords.py
+++ b/src/collective/solr/tests/test_stopwords.py
@@ -130,3 +130,19 @@ stopthree            # nostopthree
         self.assertTrue(isStopWord("stopone", self.config))
         self.assertTrue(isStopWord("stoptwo", self.config))
         self.assertTrue(isStopWord("stopthree", self.config))
+
+    def testLeadingSpaces(self):
+        # stopwords.txt does not allow leading spaces, but the registry
+        # pads it up because of the way we define it in the xml.
+        self.config.stopwords = (
+            """
+  stopone
+    stoptwo
+"""
+            + "   \n"
+        )
+        self.assertFalse(isStopWord("", self.config))
+        self.assertFalse(isStopWord("  ", self.config))
+        self.assertFalse(isStopWord("    ", self.config))
+        self.assertTrue(isStopWord("stopone", self.config))
+        self.assertTrue(isStopWord("stoptwo", self.config))


### PR DESCRIPTION
The stopwords.txt does not allow leading spaces, but the registry pads it up because of the way we define it in the xml.