### PR TITLE
Be more helpful when encountering Tika errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 ------------------
 
 - Update CI to get it working again [gforcada]
+- Be more helpful when encountering Tika errors [gyst]
+
 
 9.4.0 (2024-12-14)
 ------------------

--- a/docs/features/binary.rst
+++ b/docs/features/binary.rst
@@ -1,13 +1,27 @@
 Indexing binary documents
 *************************
 
-At this point collective.solr uses Plone's default capabilities to index binary documents.
+Collective.solr uses Plone's default capabilities to index NamedFileBlob fields, if they are declared searchable via plone.app.dexterity.textindexer.
 It does so via `portal_transforms` and installing command line tools like `wv2` or `pdftotext`.
-Work is under way to expose and use the `Apache Tika`_ Solr integration available via the `update/extract` handler.
 
-Once finished this will speed up indexing of binary documents considerably,
-as the extraction will happen out-of-process on the Solr server side.
+File and Image objects use the `Apache Tika`_ Solr integration available via the `update/extract` handler.
+
+The Tika extraction happens out-of-process on the Solr server side.
 `Apache Tika`_ also supports a much larger list of formats than can be supported by adding external command line tools.
+
+Note that you have to enable remote streaming for this to work.
+Note that you also have to configure the Java security policy to be allowed to access the blobstorage,
+if you have the ``use_tika`` setting configured to ``False`` (which means: use filesystem not network access).
+These security settings can be made by providing the proper environment variables to the solr script, for example::
+
+  SOLR_ENABLE_REMOTE_STREAMING=true SOLR_ENABLE_STREAM_BODY=true SOLR_OPTS="-Dsolr.allowPaths=/path/to/your.buildout/var/blobstorage" bin/solr-foreground
+
+If you are using buildout to configure supervisord, you can achieve this by adding the following to your buildout config::
+
+  [supervisor]
+  supervisord-environment = SOLR_ENABLE_REMOTE_STREAMING=true,SOLR_ENABLE_STREAM_BODY=true,SOLR_OPTS="-Dsolr.allowPaths=${instance:blob-storage}"
+
+Note that the buildout environment is comma separated, while the actual shell command is space separated.
 
 There is room for more improvements in this area,
 as collective.solr will still send the binary data to Solr as part of the end-user request/transaction.

--- a/src/collective/solr/indexer.py
+++ b/src/collective/solr/indexer.py
@@ -186,10 +186,21 @@ class BinaryAdder(DefaultAdder):
             root = etree.parse(response)
             data[tika_default_field] = root.find(".//str").text.strip()
         except SolrConnectionException as e:
-            logger.warn("Error %s @ %s", e, data["path_string"])
+            logger.warning("Error %s @ %s", e, data["path_string"])
+            if "Remote Streaming is disabled" in str(e.body):
+                logger.error(
+                    "Content not indexed. Remote streaming is disabled. "
+                    "See https://github.com/collective/collective.solr/issues/385 for a fix."
+                )
+            elif "access denied" in str(e.body):
+                logger.error(
+                    "Content not indexed. Java security policy disallows file access. "
+                    "Either set use_tika=True or set solr.allowPaths. "
+                    "See https://github.com/collective/collective.solr/issues/385 for a fix."
+                )
             data[tika_default_field] = ""
         except etree.XMLSyntaxError as e:
-            logger.warn("Parsing error %s @ %s.", e, data["path_string"])
+            logger.warning("Parsing error %s @ %s.", e, data["path_string"])
             data[tika_default_field] = ""
         finally:
             if use_tika:


### PR DESCRIPTION
Refs #385

On re-testing I apparently do not need to set `SOLR_ENABLE_STREAM_BODY=true`.
I've kept it since I developed and tested with this before, and it's just documentation.

https://solr.apache.org/guide/solr/latest/indexing-guide/content-streams.html