### PR TITLE
Reconfigure tika_default_field to SearchableText

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 9.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Reconfigure tika_default_field back to SearchableText [gyst]
 
 
 9.4.0 (2024-12-14)

--- a/src/collective/solr/profiles/default/metadata.xml
+++ b/src/collective/solr/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>9</version>
+  <version>10</version>
   <dependencies>
     <dependency>profile-plone.app.registry:default</dependency>
     <dependency>profile-plone.restapi:default</dependency>

--- a/src/collective/solr/profiles/default/registry.xml
+++ b/src/collective/solr/profiles/default/registry.xml
@@ -34,7 +34,7 @@
     <value key="solr_login" />
     <value key="solr_password" />
     <value key="use_tika">False</value>
-    <value key="tika_default_field">content</value>
+    <value key="tika_default_field">SearchableText</value>
     <!-- Stopwords will not get (word OR word*) simple expression, only (word).
          Notes:
          1. This will only work for multi word queries when force_simple_expression=True

--- a/src/collective/solr/setuphandlers.py
+++ b/src/collective/solr/setuphandlers.py
@@ -158,3 +158,11 @@ def migrate_to_9(context):
         registry_record.value = False
         registry.records["collective.solr.ignore_certificate_check"] = registry_record
     logger.info("Migrated to version 9")
+
+def migrate_to_10(context):
+    registry = getUtility(IRegistry)
+    registry_field = field.TextLine(title="Tika Default Field")
+    registry_record = Record(registry_field)
+    registry_record.value = "SearchableText"
+    registry.records["collective.solr.tika_default_field"] = registry_record
+    logger.info("Reconfigured tika_default_field to SearchableText")

--- a/src/collective/solr/upgrades.zcml
+++ b/src/collective/solr/upgrades.zcml
@@ -83,4 +83,14 @@
     profile="collective.solr:default"
     />
 
+  <genericsetup:upgradeStep
+    title="Reconfigure tika_default_field"
+    description="Reconfigure tika_default_field back to SearchableText"
+    source="9"
+    destination="10"
+    handler=".setuphandlers.migrate_to_10"
+    sortkey="1"
+    profile="collective.solr:default"
+    />
+
 </configure>


### PR DESCRIPTION
Refs #385

This fixes my install when running with the configuration provided by collective.solr.

I'm not so sure about this PR though, for two reasons:
- Mucking around with a registry record that may work for production installations that perhaps *did* configure the `content` field properly is a bad idea
- I lack the deeper understanding of why the `content` setting was needed in the first place, and what it is that broke this.

So, issuing this PR to show that it can be done, and documents how to fix `use_tika=True` if you use the default schema. At least we now have something to talk about.